### PR TITLE
Fix TNM map and reverse map

### DIFF
--- a/Maps/Antrag/toCTSAntrag/CTSmappings_nNGM Mapping TNM.map
+++ b/Maps/Antrag/toCTSAntrag/CTSmappings_nNGM Mapping TNM.map
@@ -1,6 +1,6 @@
 /// version = 0.1
 /// title = "CTSTNMmap"
-/// FHIR to CTS
+/// FHIR -> CTS
 
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_TNMCTS" = nNGM_Mapping_TNMCTS
 
@@ -32,7 +32,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
             };
         };
 
-        
         //Observation
         entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/tumorstadium'" then
         {
@@ -80,7 +79,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                     };
                 }; 
             };
-        
 
             // TNM-Klassifikation -> 0, 0, 2492
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -90,7 +88,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 observation -> data.itemid = 'id_2492';
                 observation.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.coding as coding, coding.version as version -> data.values as values, values.value = version;
             };
-            
 
             // Date of assessment -> 1, 0, 1378
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -100,7 +97,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 observation -> data.itemid = 'id_1378';
                 observation.effectiveDateTime as effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
             };
-            
 
             // Prafix -> 1, 0, 1379
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -122,11 +118,10 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                         code -> data.values as values, values.value = 'y - Zustand nach Therapie';
                     };
                 };
-            };
-            
+            }; 
 
             // Tumor (T)
-            // Grï¿½ï¿½e und Ausdehnung des Tumors -> 1, 0, id_1380
+            // Größe und Ausdehnung des Tumors -> 1, 0, id_1380
             observation -> tgt.operations as operations collate, operations.data as data then
             {
                 observation.component as component then
@@ -142,7 +137,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                     };
                 };
             };
-        
 
             // prafix -> 1, 0, id_2493
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -163,7 +157,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 };
             };
    
-
             // Suffix -> 1, 0, id_2495
             observation -> tgt.operations as operations collate, operations.data as data then
             {
@@ -183,9 +176,8 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 };
             };
         
-
             // Lymphknoten (N)
-            // Grï¿½ï¿½e und Ausdehnung des Tumors -> 1, 0, 1381
+            // Größe und Ausdehnung des Tumors -> 1, 0, 1381
             observation -> tgt.operations as operations collate, operations.data as data then
             {
                 observation.component as component then
@@ -201,7 +193,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                     };
                 };
             };
-            
 
             // Prafix -> 1, 0, 2497
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -222,7 +213,6 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 };
             };
         
-
             // Metastasen(M)
             // Abwesenheit oder Vorhandensein von Metastasen -> 1, 0, 1382
             observation -> tgt.operations as operations collate, operations.data as data then
@@ -271,6 +261,5 @@ group TransformTNMOperation(source src: Bundle, target tgt: CTS_Transport)
                 coding.code as code -> data.values as values, values.value = code;
             };
         };
-             
     };
 }

--- a/Maps/Antrag/toFHIRAntrag/FHIRmappings_nNGM Mapping TNM.map
+++ b/Maps/Antrag/toFHIRAntrag/FHIRmappings_nNGM Mapping TNM.map
@@ -7,7 +7,7 @@ TODO
 
 /// version = 0.1
 /// title = "TNMMap"
-/// CTS to FHIR
+/// CTS -> FHIR
 
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_TNMMap" = nNGM_Mapping_TNMMap
 


### PR DESCRIPTION
Reverse map is completely reworked with correct data blocks now. The CTStoFHIR map now checks whether the data is there and uses the specimen resource to store the biopsy id.