### PR TITLE
Add suffixes to each group according to map

### DIFF
--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Anforderung.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Anforderung.map
@@ -52,7 +52,7 @@ group CreateServiceRequestAnforderung(source operations: BackboneElement, target
     // Create resource if bool set to true
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('ServiceRequest') as serviceRequest then 
     {
-        operations then TransformGewebeDiagnostikServiceRequest(operations, serviceRequest, composition, section);
+        operations then TransformGewebeDiagnostikServiceRequestAnforderung(operations, serviceRequest, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(serviceRequest, '\'ServiceRequest/\' + $this.id');
     };
 
@@ -69,13 +69,13 @@ group CreateServiceRequestAnforderung(source operations: BackboneElement, target
     // Create resource if bool set to true
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('ServiceRequest') as serviceRequest then 
     {
-        operations then TransformBlutDiagnostikServiceRequest(operations, serviceRequest, composition, section);
+        operations then TransformBlutDiagnostikServiceRequestAnforderung(operations, serviceRequest, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(serviceRequest, '\'ServiceRequest/\' + $this.id');
     };
 }
 
 /* ------------------------------ ServiceRequest - GewebeDiagnostik ---------------------------- */
-group TransformGewebeDiagnostikServiceRequest(source operations: BackboneElement, target tgt: ServiceRequest, target composition: Composition, target section: BackboneElement)
+group TransformGewebeDiagnostikServiceRequestAnforderung(source operations: BackboneElement, target tgt: ServiceRequest, target composition: Composition, target section: BackboneElement)
 {
     // profile with profile URL
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/ServiceRequest/nNGM/tumorblock';
@@ -258,7 +258,7 @@ group TransformGewebeDiagnostikServiceRequest(source operations: BackboneElement
 }
 
 /* ------------------------------ ServiceRequest - BlutDiagnostik ---------------------------- */
-group TransformBlutDiagnostikServiceRequest(source operations: BackboneElement, target tgt: ServiceRequest, target composition: Composition, target section: BackboneElement)
+group TransformBlutDiagnostikServiceRequestAnforderung(source operations: BackboneElement, target tgt: ServiceRequest, target composition: Composition, target section: BackboneElement)
 {
     // profile with profile URL
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/ServiceRequest/nNGM/testung';
@@ -381,7 +381,7 @@ group CreateSpecimenAnforderung(source operations: BackboneElement, target bundl
         // Create resource if bool set to true
         operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Specimen') as specimen then 
         {
-            operations then TransformGewebeDiagnostikSpecimen(operations, specimen, composition, section);
+            operations then TransformGewebeDiagnostikSpecimenAnforderung(operations, specimen, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(specimen, '\'Specimen/\' + $this.id');
         };
 
@@ -399,14 +399,14 @@ group CreateSpecimenAnforderung(source operations: BackboneElement, target bundl
         // Create resource if bool set to true
         operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Specimen') as specimen then 
         {
-            operations then TransformBlutDiagnostikSpecimen(operations, specimen, composition, section);
+            operations then TransformBlutDiagnostikSpecimenAnforderung(operations, specimen, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(specimen, '\'Specimen/\' + $this.id');
         };
     };
 }
 
 /* ------------------------------ Specimen - GewebeDiagnostik ---------------------------- */
-group TransformGewebeDiagnostikSpecimen(source operations: BackboneElement, target tgt: Specimen, target composition: Composition, target section: BackboneElement)
+group TransformGewebeDiagnostikSpecimenAnforderung(source operations: BackboneElement, target tgt: Specimen, target composition: Composition, target section: BackboneElement)
 {
     //profile with profile URL
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Specimen/nNGM';
@@ -483,7 +483,7 @@ group TransformGewebeDiagnostikSpecimen(source operations: BackboneElement, targ
 }
 
 /* ------------------------------ Specimen - BlutDiagnostik ---------------------------- */
-group TransformBlutDiagnostikSpecimen(source operations: BackboneElement, target tgt: Specimen, target composition: Composition, target section: BackboneElement)
+group TransformBlutDiagnostikSpecimenAnforderung(source operations: BackboneElement, target tgt: Specimen, target composition: Composition, target section: BackboneElement)
 {
     // profile with profile URL
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Specimen/nNGM';

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Basisangaben.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Basisangaben.map
@@ -38,21 +38,21 @@ group TransformBundleBasisangaben(source operations: BackboneElement, target bun
         operations then CreatePractitionerBasisangaben(operations, bundle, composition, section);
         
         // Consent
-        operations then CreateConsentTeilnahme(operations, bundle, composition, section);
-        operations then CreateConsentDatenschutz(operations, bundle, composition, section);
+        operations then CreateConsentTeilnahmeBasisangaben(operations, bundle, composition, section);
+        operations then CreateConsentDatenschutzBasisangaben(operations, bundle, composition, section);
         operations then CreateConsentEinwilligung1aBasisangaben(operations, bundle, composition, section);
         operations then CreateConsentEinwilligung1bBasisangaben(operations, bundle, composition, section);
-        operations then CreateConsentEinwilligung2(operations, bundle, composition, section);
-        operations then CreateConsentVersorgung1(operations, bundle, composition, section);
-        operations then CreateConsentVersorgung2(operations, bundle, composition, section);
-        operations then CreateConsentForschung1(operations, bundle, composition, section);
-        operations then CreateConsentForschung2(operations, bundle, composition, section);
-        operations then CreateConsentForschung3(operations, bundle, composition, section);
-        operations then CreateConsentForschung4(operations, bundle, composition, section);
-        operations then CreateConsentForschung5(operations, bundle, composition, section);
-        operations then CreateConsentForschung6(operations, bundle, composition, section);
-        operations then CreateConsentForschung7(operations, bundle, composition, section);
-        operations then CreateConsentForschung8(operations, bundle, composition, section);
+        operations then CreateConsentEinwilligung2Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentVersorgung1Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentVersorgung2Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung1Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung2Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung3Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung4Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung5Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung6Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung7Basisangaben(operations, bundle, composition, section);
+        operations then CreateConsentForschung8Basisangaben(operations, bundle, composition, section);
     };
 }
 
@@ -157,7 +157,7 @@ group TransformServiceRequestBasisangaben(source operations: BackboneElement, ta
            dataAbsentReason.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
            dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
     
-    operations then TransformServiceRequestRequesterExtension(operations, tgt);
+    operations then TransformServiceRequestRequesterExtensionBasisangaben(operations, tgt);
 
     operations.data as data then
     {
@@ -230,7 +230,7 @@ group TransformServiceRequestBasisangaben(source operations: BackboneElement, ta
 }
 
 /* -------------------------------------- Create double extension for ServiceRequest.Requester -------------------------------------------- */
-group TransformServiceRequestRequesterExtension(source operations: BackboneElement, target tgt: ServiceRequest)
+group TransformServiceRequestRequesterExtensionBasisangaben(source operations: BackboneElement, target tgt: ServiceRequest)
 {
     operations.data as data then
     {
@@ -782,7 +782,7 @@ group TransformPractitionerBasisangaben(source operations: BackboneElement, targ
 }
 
 /* ------------------------------ Check if Consent Teilnahme is required ---------------------------- */
-group CreateConsentTeilnahme(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentTeilnahmeBasisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -796,13 +796,13 @@ group CreateConsentTeilnahme(source operations: BackboneElement, target bundle: 
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentTeilnahme(operations, consent, composition, section);
+        operations then TransformConsentTeilnahmeBasisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Teilnahme ---------------------------- */
-group TransformConsentTeilnahme(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentTeilnahmeBasisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -863,7 +863,7 @@ group TransformConsentTeilnahme(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Check if Consent Datenschutz is required ---------------------------- */
-group CreateConsentDatenschutz(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentDatenschutzBasisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -877,13 +877,13 @@ group CreateConsentDatenschutz(source operations: BackboneElement, target bundle
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentDatenschutz(operations, consent, composition, section);
+        operations then TransformConsentDatenschutzBasisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Datenschutz ---------------------------- */
-group TransformConsentDatenschutz(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentDatenschutzBasisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1109,7 +1109,7 @@ group TransformConsentEinwilligung1bBasisangaben(source operations: BackboneElem
 }
 
 /* ------------------------------ Check if Consent Einwilligung 2 is required ---------------------------- */
-group CreateConsentEinwilligung2(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentEinwilligung2Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1123,13 +1123,13 @@ group CreateConsentEinwilligung2(source operations: BackboneElement, target bund
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentEinwilligung2(operations, consent, composition, section);
+        operations then TransformConsentEinwilligung2Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Einwilligung 2 ---------------------------- */
-group TransformConsentEinwilligung2(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentEinwilligung2Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1190,7 +1190,7 @@ group TransformConsentEinwilligung2(source operations: BackboneElement, target t
 }
 
 /* ------------------------------ Check if Consent Versorgung 1 is required ---------------------------- */
-group CreateConsentVersorgung1(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentVersorgung1Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1204,13 +1204,13 @@ group CreateConsentVersorgung1(source operations: BackboneElement, target bundle
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentVersorgung1(operations, consent, composition, section);
+        operations then TransformConsentVersorgung1Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Versorgung 1 ---------------------------- */
-group TransformConsentVersorgung1(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentVersorgung1Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1270,7 +1270,7 @@ group TransformConsentVersorgung1(source operations: BackboneElement, target tgt
 }
 
 /* ------------------------------ Check if Consent Versorgung 2 is required ---------------------------- */
-group CreateConsentVersorgung2(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentVersorgung2Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1284,13 +1284,13 @@ group CreateConsentVersorgung2(source operations: BackboneElement, target bundle
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentVersorgung2(operations, consent, composition, section);
+        operations then TransformConsentVersorgung2Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Versorgung 2 ---------------------------- */
-group TransformConsentVersorgung2(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentVersorgung2Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1350,7 +1350,7 @@ group TransformConsentVersorgung2(source operations: BackboneElement, target tgt
 }
 
 /* ------------------------------ Check if Consent Forschung 1 is required ---------------------------- */
-group CreateConsentForschung1(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung1Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1364,13 +1364,13 @@ group CreateConsentForschung1(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung1(operations, consent, composition, section);
+        operations then TransformConsentForschung1Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 1 ---------------------------- */
-group TransformConsentForschung1(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung1Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1432,7 +1432,7 @@ group TransformConsentForschung1(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 2 is required ---------------------------- */
-group CreateConsentForschung2(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung2Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1446,13 +1446,13 @@ group CreateConsentForschung2(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung2(operations, consent, composition, section);
+        operations then TransformConsentForschung2Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 2 ---------------------------- */
-group TransformConsentForschung2(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung2Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1514,7 +1514,7 @@ group TransformConsentForschung2(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 3 is required ---------------------------- */
-group CreateConsentForschung3(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung3Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1528,13 +1528,13 @@ group CreateConsentForschung3(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung3(operations, consent, composition, section);
+        operations then TransformConsentForschung3Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 3 ---------------------------- */
-group TransformConsentForschung3(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung3Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1597,7 +1597,7 @@ group TransformConsentForschung3(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 4 is required ---------------------------- */
-group CreateConsentForschung4(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung4Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1611,13 +1611,13 @@ group CreateConsentForschung4(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung4(operations, consent, composition, section);
+        operations then TransformConsentForschung4Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 4 ---------------------------- */
-group TransformConsentForschung4(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung4Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1680,7 +1680,7 @@ group TransformConsentForschung4(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 5 is required ---------------------------- */
-group CreateConsentForschung5(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung5Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1694,13 +1694,13 @@ group CreateConsentForschung5(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung5(operations, consent, composition, section);
+        operations then TransformConsentForschung5Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 5 ---------------------------- */
-group TransformConsentForschung5(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung5Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1763,7 +1763,7 @@ group TransformConsentForschung5(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 6 is required ---------------------------- */
-group CreateConsentForschung6(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung6Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1777,13 +1777,13 @@ group CreateConsentForschung6(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung6(operations, consent, composition, section);
+        operations then TransformConsentForschung6Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 6 ---------------------------- */
-group TransformConsentForschung6(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung6Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1843,7 +1843,7 @@ group TransformConsentForschung6(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 7 is required ---------------------------- */
-group CreateConsentForschung7(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung7Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1857,13 +1857,13 @@ group CreateConsentForschung7(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung7(operations, consent, composition, section);
+        operations then TransformConsentForschung7Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 7 ---------------------------- */
-group TransformConsentForschung7(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
+group TransformConsentForschung7Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';
@@ -1925,7 +1925,7 @@ group TransformConsentForschung7(source operations: BackboneElement, target tgt:
 }
 
 /* ------------------------------ Check if Consent Forschung 8 is required ---------------------------- */
-group CreateConsentForschung8(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateConsentForschung8Basisangaben(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     // Check whether resource should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -1939,13 +1939,13 @@ group CreateConsentForschung8(source operations: BackboneElement, target bundle:
 
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Consent') as consent then
     {
-        operations then TransformConsentForschung8(operations, consent, composition, section);
+        operations then TransformConsentForschung8Basisangaben(operations, consent, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(consent, '\'Consent/\' + $this.id');
     };
 }
 
 /* ------------------------------ Consent Forschung 8 ---------------------------- */
-group TransformConsentForschung8(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement) 
+group TransformConsentForschung8Basisangaben(source operations: BackboneElement, target tgt: Consent, target composition: Composition, target section: BackboneElement) 
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Consent/nNGM';

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Fast Track.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Fast Track.map
@@ -142,13 +142,13 @@ group TransformDiagnosticReportFastTrack(source operations: BackboneElement, tar
                 let EGFFR19 = 'EGFR Exon 19';
                 let EGFFR20 = 'EGFR Exon 20';
                 let EGFFR21 = 'EGFR Exon 21';
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR19, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR20, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR21, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR19, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR20, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR21, reference);
             };
             values.value where "$this.value != 'EGFR Exon 19-21'" then
             {
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, value, reference);
             };
         };
     };
@@ -199,7 +199,7 @@ group CreateObservationFastTrack(source operations: BackboneElement, target bund
         // BRAF Exon 15
         values.value as value where "value = 'BRAF Exon 15'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationBRAFExon15(operations, observation, composition, section);
+            operations then TransformObservationBRAFExon15FastTrack(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // EGFR 19-21
@@ -207,31 +207,31 @@ group CreateObservationFastTrack(source operations: BackboneElement, target bund
         {
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationEGFRExon19(operations, observation, composition, section);
+                operations then TransformObservationEGFRExon19FastTrack(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id'); 
             };
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationEGFRExon20(operations, observation, composition, section);
+                operations then TransformObservationEGFRExon20FastTrack(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id'); 
             };
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationEGFRExon21(operations, observation, composition, section);
+                operations then TransformObservationEGFRExon21FastTrack(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id'); 
             };                    
         };
         // KRAS Exon 2
         values.value as value where "value = 'KRAS Exon 2'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationKRASExon2(operations, observation, composition, section);
+            operations then TransformObservationKRASExon2FastTrack(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
     };
 }
 
 /* ------------------------------ Observation BRAF Exon 15 ---------------------------- */
-group TransformObservationBRAFExon15(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationBRAFExon15FastTrack(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
     
@@ -239,7 +239,7 @@ group TransformObservationBRAFExon15(source operations: BackboneElement, target 
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C158854', 'BRAF Exon 15 Mutation');
 
     //Fast track category
-    operations then MapSopNumberCategoryMethodStatus(operations, tgt);
+    operations then MapSopNumberCategoryMethodStatusFastTrack(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -316,7 +316,7 @@ group TransformObservationBRAFExon15(source operations: BackboneElement, target 
 }
 
 /* ------------------------------ Observation EGFR Exon 19 ---------------------------- */
-group TransformObservationEGFRExon19(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationEGFRExon19FastTrack(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
 
@@ -324,13 +324,13 @@ group TransformObservationEGFRExon19(source operations: BackboneElement, target 
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128662','EGFR Exon 19 Mutation');
 
     //Fast track category
-    operations then MapSopNumberCategoryMethodStatus(operations, tgt);
+    operations then MapSopNumberCategoryMethodStatusFastTrack(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     // Date of Assessment, Assay, Hersteller
-    operations then MapEGFREXO1921(operations, tgt);
+    operations then MapEGFREXO1921FastTrack(operations, tgt);
     
     // Access data
     operations.data as data then
@@ -378,7 +378,7 @@ group TransformObservationEGFRExon19(source operations: BackboneElement, target 
 }
 
 /* ------------------------------ Observation EGFR Exon 20 ---------------------------- */
-group TransformObservationEGFRExon20(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationEGFRExon20FastTrack(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
 
@@ -386,13 +386,13 @@ group TransformObservationEGFRExon20(source operations: BackboneElement, target 
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128663','EGFR Exon 20 Mutation');
 
     //Fast track category
-    operations then MapSopNumberCategoryMethodStatus(operations, tgt);
+    operations then MapSopNumberCategoryMethodStatusFastTrack(operations, tgt);
     
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     // Date of Assessment, Assay, Hersteller
-    operations then MapEGFREXO1921(operations, tgt);
+    operations then MapEGFREXO1921FastTrack(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -440,7 +440,7 @@ group TransformObservationEGFRExon20(source operations: BackboneElement, target 
 }
 
 /* ------------------------------ Observation EGFR Exon 21 ---------------------------- */
-group TransformObservationEGFRExon21(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationEGFRExon21FastTrack(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
 
@@ -448,13 +448,13 @@ group TransformObservationEGFRExon21(source operations: BackboneElement, target 
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128666','EGFR Exon 21 Mutation');
 
     //Fast track category
-    operations then MapSopNumberCategoryMethodStatus(operations, tgt);
+    operations then MapSopNumberCategoryMethodStatusFastTrack(operations, tgt);
     
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     // Date of Assessment, Assay, Hersteller
-    operations then MapEGFREXO1921(operations, tgt);
+    operations then MapEGFREXO1921FastTrack(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -502,7 +502,7 @@ group TransformObservationEGFRExon21(source operations: BackboneElement, target 
 }
 
 /* ------------------------------ Observation KRAS Exon 2 ---------------------------- */
-group TransformObservationKRASExon2(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationKRASExon2FastTrack(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
 
@@ -510,7 +510,7 @@ group TransformObservationKRASExon2(source operations: BackboneElement, target t
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C135715','KRAS Exon 2 Mutation');
 
     //Fast track category
-    operations then MapSopNumberCategoryMethodStatus(operations, tgt);
+    operations then MapSopNumberCategoryMethodStatusFastTrack(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -683,13 +683,13 @@ group TransformServiceRequestFastTrack(source operations: BackboneElement, targe
                 let EGFFR19 = 'EGFR Exon 19';
                 let EGFFR20 = 'EGFR Exon 20';
                 let EGFFR21 = 'EGFR Exon 21';
-                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR19, reference);
-                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR20, reference);
-                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, EGFFR21, reference);
+                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR19, reference);
+                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR20, reference);
+                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR21, reference);
             };
             values.value where "$this.value != 'EGFR Exon 19-21'" then
             {
-                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, value, reference);
             };
         };
 
@@ -735,7 +735,7 @@ group TransformFastTrackStatusExtension(source operations: BackboneElement, targ
 }
 
 /*-----------------HELPERS----------------------------*/
-group MapSopNumberCategoryMethodStatus(source operations: BackboneElement, target tgt: Observation)
+group MapSopNumberCategoryMethodStatusFastTrack(source operations: BackboneElement, target tgt: Observation)
 {
     // Method
     operations -> tgt.method = cc('http://ncit.nci.nih.gov','C101293');
@@ -761,7 +761,7 @@ group MapSopNumberCategoryMethodStatus(source operations: BackboneElement, targe
     };
 }
 
-group MapEGFREXO1921(source operations: BackboneElement, target tgt: Observation)
+group MapEGFREXO1921FastTrack(source operations: BackboneElement, target tgt: Observation)
 {
     // ------------------------------ EGFR Exon 19-21 ---------------------------- 
     operations.data as data then
@@ -794,7 +794,7 @@ group MapEGFREXO1921(source operations: BackboneElement, target tgt: Observation
     };
 }
 
-group SetReferenceToObservation(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationFastTrack(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'BRAF Exon 15'" then 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
@@ -205,12 +205,12 @@ group CreateObservationHistologie(source operations: BackboneElement, target bun
     // Create resource if bool set to true
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
     {
-        operations then TransformObservation(operations, observation, composition, section);
+        operations then TransformObservationHistologie(operations, observation, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
     };
 }
 
-group TransformObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationHistologie(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Resource information
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie';
@@ -278,7 +278,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
             values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8250/3');
             }; 
         };
@@ -288,7 +288,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
             values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8551/3');
             }; 
         };
@@ -298,7 +298,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
             values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8260/3');
             }; 
         };
@@ -308,7 +308,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
             values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8265/3');
             }; 
         };
@@ -318,7 +318,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
             values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8230/3');
             }; 
         };
@@ -328,7 +328,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
         {
              values.value as wachstumsmuster -> tgt.component = create('BackboneElement') as component then
             {
-                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(wachstumsmuster, quantity);
+                wachstumsmuster -> component.valueQuantity = create('Quantity') as quantity then TMapPercentageValueHistologie(wachstumsmuster, quantity);
                 wachstumsmuster -> component.code = cc('urn:oid:2.16.840.1.113883.6.43.1', '8490/3');
             }; 
         };
@@ -336,7 +336,7 @@ group TransformObservation(source operations: BackboneElement, target tgt: Obser
 }
 
 /* ------------------------------ Helper function ---------------------------- */
-group MapPercentageValue(source src: string, target tgt: Quantity)
+group TMapPercentageValueHistologie(source src: string, target tgt: Quantity)
 {
     src -> tgt.value = src,
             tgt.system = 'http://unitsofmeasure.org',

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Immunhistochemie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Immunhistochemie.map
@@ -23,9 +23,9 @@ group TransformBundleImmunhistochemie(source operations: BackboneElement, target
 {
     operations -> composition.section = create('BackboneElement') as section, section.code = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/sections', 'immunhistochemie') then
     {
-        operations then CreateServiceRequestIHC(operations, bundle, composition, section);
+        // operations then CreateServiceRequestIHC(operations, bundle, composition, section);
         // operations then CreateSpecimenIHC(operations, bundle, composition, section);
-        operations then CreateDiagnosticReportIHC(operations, bundle, composition, section);
+        // operations then CreateDiagnosticReportIHC(operations, bundle, composition, section);
         operations then CreateObservationIHC(operations, bundle, composition, section);
     };
 }
@@ -121,7 +121,7 @@ group TransformServiceRequestIHC(source operations: BackboneElement, target tgt:
         // Observations
         data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'id_2508'" then
         {
-            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationIHC(operations, value, reference);
         };
 
         // Specimen
@@ -269,7 +269,7 @@ group TransformDiagnosticReportIHC(source operations: BackboneElement, target tg
         // Observations
         data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'id_2508'" then
         {
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationIHC(operations, value, reference);
         };
     };
 }
@@ -283,83 +283,83 @@ group CreateObservationIHC(source operations: BackboneElement, target bundle: Bu
         // BRAF
         values.value as value where "value = 'BRAF'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationBRAF(operations, observation, composition, section);
+            operations then TransformObservationBRAFIHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // CK7
         values.value as value where "value = 'CK7'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationCK7(operations, observation, composition, section);
+            operations then TransformObservationCK7IHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // MIB1
         values.value as value where "value = 'MIB1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationMIB1(operations, observation, composition, section);
+            operations then TransformObservationMIB1IHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // Napsin A
         values.value as value where "value = 'Napsin A'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationNAPSINA(operations, observation, composition, section);
+            operations then TransformObservationNAPSINAIHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // P40
         values.value as value where "value = 'P40'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationP40(operations, observation, composition, section);
+            operations then TransformObservationP40IHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // Synaptophysin
         values.value as value where "value = 'Synaptophysin'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationSynaptophysin(operations, observation, composition, section);
+            operations then TransformObservationSynaptophysinIHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // TTF1
         values.value as value where "value = 'TTF1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationTTF1(operations, observation, composition, section);
+            operations then TransformObservationTTF1IHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // ALK
         values.value as value where "value = 'ALK'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationALK(operations, observation, composition, section);
+            operations then TTransformObservationALKIHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // MET
         values.value as value where "value = 'MET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationMET(operations, observation, composition, section);
+            operations then TransformObservationMETIHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // PD-L1
         values.value as value where "value = 'PD-L1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationPDL1(operations, observation, composition, section);
+            operations then TransformObservationPDL1IHC(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
 
         // ROS1
         values.value as value where "value = 'ROS1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationROS1(operations, observation, composition, section);
-            operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
+            operations then TransTransformObservationROS1IHC(operations, observation, composition, section);
+            operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');  
         };
     };
 }
 
-group TransformObservationBRAF(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationBRAFIHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -513,7 +513,7 @@ group TransformObservationBRAF(source operations: BackboneElement, target tgt: O
     };
 }
 
-group TransformObservationCK7(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationCK7IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -667,7 +667,7 @@ group TransformObservationCK7(source operations: BackboneElement, target tgt: Ob
     };
 }
 
-group TransformObservationMIB1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationMIB1IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -822,7 +822,7 @@ group TransformObservationMIB1(source operations: BackboneElement, target tgt: O
     };
 }
 
-group TransformObservationNAPSINA(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationNAPSINAIHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -976,7 +976,7 @@ group TransformObservationNAPSINA(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformObservationP40(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationP40IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -1130,7 +1130,7 @@ group TransformObservationP40(source operations: BackboneElement, target tgt: Ob
     };
 }
 
-group TransformObservationSynaptophysin(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationSynaptophysinIHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -1284,7 +1284,7 @@ group TransformObservationSynaptophysin(source operations: BackboneElement, targ
     };
 }
 
-group TransformObservationTTF1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationTTF1IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -1438,7 +1438,7 @@ group TransformObservationTTF1(source operations: BackboneElement, target tgt: O
     };
 }
 
-group TransformObservationALK(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TTransformObservationALKIHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -1593,7 +1593,7 @@ group TransformObservationALK(source operations: BackboneElement, target tgt: Ob
     };
 }
 
-group TransformObservationMET(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationMETIHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
     
@@ -1779,7 +1779,7 @@ group TransformObservationMET(source operations: BackboneElement, target tgt: Ob
     };
 }
 
-group TransformObservationPDL1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationPDL1IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -1920,7 +1920,7 @@ group TransformObservationPDL1(source operations: BackboneElement, target tgt: O
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueIHC(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C127771');
             };
         };
@@ -1930,7 +1930,7 @@ group TransformObservationPDL1(source operations: BackboneElement, target tgt: O
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueIHC(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'tcell-surface-ratio');
             };
         };
@@ -1944,7 +1944,7 @@ group TransformObservationPDL1(source operations: BackboneElement, target tgt: O
     };
 }
 
-group TransformObservationROS1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransTransformObservationROS1IHC(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
@@ -2099,7 +2099,7 @@ group TransformObservationROS1(source operations: BackboneElement, target tgt: O
 }
 
 /*-----------------HELPERS----------------------------*/
-group MapPercentageValue(source src: string, target tgt: Quantity)
+group MapPercentageValueIHC(source src: string, target tgt: Quantity)
 {
     src -> tgt.value = src,
             tgt.system = 'http://unitsofmeasure.org',
@@ -2124,7 +2124,7 @@ group MapIHCMethode(source operation: BackboneElement, target tgt: Observation)
     operation -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23020');
 }
 
-group SetReferenceToObservation(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationIHC(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'BRAF'" then 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Molekularpathologie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Molekularpathologie.map
@@ -136,13 +136,11 @@ group TransformDiagnosticReportMP(source operations: BackboneElement, target tgt
         // Observations CISH and FISH
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2509'" then
         {
-            let cish = 'CISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, cish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationCISHMP(operations, value, reference);
         };
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2510'" then
         {
-            let fish = 'FISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, fish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFISHMP(operations, value, reference);
         };
     };
 }
@@ -273,13 +271,11 @@ group TransformServiceRequestMP(source operations: BackboneElement, target tgt: 
         // Observations CISH and FISH
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2509'" then
         {
-            let cish = 'CISH';
-            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, cish, value, reference);
+            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationCISHMP(operations, value, reference);
         };
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2510'" then
         {
-            let fish = 'FISH';
-            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, fish, value, reference);
+            values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFISHMP(operations, value, reference);
         };
 
         // Specimen
@@ -332,25 +328,25 @@ group CreateObservationMP(source operations: BackboneElement, target bundle: Bun
         // ALK
         values.value as value where "value = 'ALK'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformALKCISHObservation(operations, observation, composition, section);
+            operations then TransformALKCISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // MET
         values.value as value where "value = 'MET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformMETCISHObservation(operations, observation, composition, section);
+            operations then TransformMETCISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // RET
         values.value as value where "value = 'RET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformRETCISHObservation(operations, observation, composition, section);
+            operations then TransformRETCISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // ROS1
         values.value as value where "value = 'ROS1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformROS1CISHObservation(operations, observation, composition, section);
+            operations then TransformROS1CISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
     };
@@ -361,31 +357,31 @@ group CreateObservationMP(source operations: BackboneElement, target bundle: Bun
         // ALK
         values.value as value where "value = 'ALK'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformALKFISHObservation(operations, observation, composition, section);
+            operations then TransformALKFISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // MET
         values.value as value where "value = 'MET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformMETFISHObservation(operations, observation, composition, section);
+            operations then TransformMETFISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // RET
         values.value as value where "value = 'RET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformRETFISHObservation(operations, observation, composition, section);
+            operations then TransformRETFISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
         // ROS1
         values.value as value where "value = 'ROS1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformROS1FISHObservation(operations, observation, composition, section);
+            operations then TransformROS1FISHObservationMP(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');        
         };
     };
 }
 
-group TransformALKCISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformALKCISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let ALK = 'ALK';
 
@@ -400,8 +396,8 @@ group TransformALKCISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23022');
 
-    operations then MapDateOfAssessment(operations, ALK, tgt);
-    operations then MapCode(operations, ALK, tgt);
+    operations then MapDateOfAssessmentMP(operations, ALK, tgt);
+    operations then MapCodeMP(operations, ALK, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -470,7 +466,7 @@ group TransformALKCISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -484,7 +480,7 @@ group TransformALKCISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformALKFISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformALKFISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let ALK = 'ALK';
 
@@ -499,8 +495,8 @@ group TransformALKFISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C17563');
 
-    operations then MapDateOfAssessment(operations, ALK, tgt);
-    operations then MapCode(operations, ALK, tgt);
+    operations then MapDateOfAssessmentMP(operations, ALK, tgt);
+    operations then MapCodeMP(operations, ALK, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -569,7 +565,7 @@ group TransformALKFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -579,7 +575,7 @@ group TransformALKFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as polysomie -> tgt.component = create('BackboneElement') as polysomiecomponent then
             {
-                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(polysomie, quantity);
+                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(polysomie, quantity);
                 polysomie -> polysomiecomponent.code = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -593,7 +589,7 @@ group TransformALKFISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformMETCISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformMETCISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let MET = 'MET';
 
@@ -608,8 +604,8 @@ group TransformMETCISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23022');
 
-    operations then MapDateOfAssessment(operations, MET, tgt);
-    operations then MapCode(operations, MET, tgt);
+    operations then MapDateOfAssessmentMP(operations, MET, tgt);
+    operations then MapCodeMP(operations, MET, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -717,7 +713,7 @@ group TransformMETCISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformMETFISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformMETFISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let MET = 'MET';
 
@@ -732,8 +728,8 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C17563');
 
-    operations then MapDateOfAssessment(operations, MET, tgt);
-    operations then MapCode(operations, MET, tgt);
+    operations then MapDateOfAssessmentMP(operations, MET, tgt);
+    operations then MapCodeMP(operations, MET, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -858,7 +854,7 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as met15signal -> tgt.component = create('BackboneElement') as met15signalcomponent then
             {
-                met15signal -> met15signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(met15signal, quantity);
+                met15signal -> met15signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(met15signal, quantity);
                 met15signal -> met15signalcomponent.code = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '15-met-ratio');
             };
         };
@@ -868,7 +864,7 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as met5signal -> tgt.component = create('BackboneElement') as met5signalcomponent then
             {
-                met5signal -> met5signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(met5signal, quantity);
+                met5signal -> met5signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(met5signal, quantity);
                 met5signal -> met5signalcomponent.code = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '5-met-ratio');
             };
         };
@@ -878,7 +874,7 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as met4signal -> tgt.component = create('BackboneElement') as met4signalcomponent then
             {
-                met4signal -> met4signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(met4signal, quantity);
+                met4signal -> met4signalcomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(met4signal, quantity);
                 met4signal -> met4signalcomponent.code = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '4-met-ratio');
             };
         };
@@ -938,7 +934,7 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as polysomie -> tgt.component = create('BackboneElement') as polysomiecomponent then
             {
-                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(polysomie, quantity);
+                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(polysomie, quantity);
                 polysomie -> polysomiecomponent.code = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -952,7 +948,7 @@ group TransformMETFISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformRETCISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformRETCISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let RET = 'RET';
 
@@ -967,8 +963,8 @@ group TransformRETCISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23022');
 
-    operations then MapDateOfAssessment(operations, RET, tgt);
-    operations then MapCode(operations, RET, tgt);
+    operations then MapDateOfAssessmentMP(operations, RET, tgt);
+    operations then MapCodeMP(operations, RET, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1038,7 +1034,7 @@ group TransformRETCISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1052,7 +1048,7 @@ group TransformRETCISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformRETFISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformRETFISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let RET = 'RET';
 
@@ -1067,8 +1063,8 @@ group TransformRETFISHObservation(source operations: BackboneElement, target tgt
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C17563');
 
-    operations then MapDateOfAssessment(operations, RET, tgt);
-    operations then MapCode(operations, RET, tgt);
+    operations then MapDateOfAssessmentMP(operations, RET, tgt);
+    operations then MapCodeMP(operations, RET, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1138,7 +1134,7 @@ group TransformRETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1148,7 +1144,7 @@ group TransformRETFISHObservation(source operations: BackboneElement, target tgt
         {
             values.value as polysomie -> tgt.component = create('BackboneElement') as polysomiecomponent then
             {
-                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(polysomie, quantity);
+                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(polysomie, quantity);
                 polysomie -> polysomiecomponent.code = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1162,7 +1158,7 @@ group TransformRETFISHObservation(source operations: BackboneElement, target tgt
     };
 }
 
-group TransformROS1CISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformROS1CISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let ROS1 = 'ROS1';
 
@@ -1177,8 +1173,8 @@ group TransformROS1CISHObservation(source operations: BackboneElement, target tg
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23022');
 
-    operations then MapDateOfAssessment(operations, ROS1, tgt);
-    operations then MapCode(operations, ROS1, tgt);
+    operations then MapDateOfAssessmentMP(operations, ROS1, tgt);
+    operations then MapCodeMP(operations, ROS1, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1248,7 +1244,7 @@ group TransformROS1CISHObservation(source operations: BackboneElement, target tg
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1258,7 +1254,7 @@ group TransformROS1CISHObservation(source operations: BackboneElement, target tg
         {
             values.value as polysomie -> tgt.component = create('BackboneElement') as polysomiecomponent then
             {
-                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(polysomie, quantity);
+                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(polysomie, quantity);
                 polysomie -> polysomiecomponent.code = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1272,7 +1268,7 @@ group TransformROS1CISHObservation(source operations: BackboneElement, target tg
     };
 }
 
-group TransformROS1FISHObservation(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformROS1FISHObservationMP(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     let ROS1 = 'ROS1';
 
@@ -1287,8 +1283,8 @@ group TransformROS1FISHObservation(source operations: BackboneElement, target tg
     // methode
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C17563');
 
-    operations then MapDateOfAssessment(operations, ROS1, tgt);
-    operations then MapCode(operations, ROS1, tgt);
+    operations then MapDateOfAssessmentMP(operations, ROS1, tgt);
+    operations then MapCodeMP(operations, ROS1, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1357,7 +1353,7 @@ group TransformROS1FISHObservation(source operations: BackboneElement, target tg
         {
             values.value as ergebnis -> tgt.component = create('BackboneElement') as postumorzellencomponent then
             {
-                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(ergebnis, quantity);
+                ergebnis -> postumorzellencomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(ergebnis, quantity);
                 ergebnis -> postumorzellencomponent.code = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1367,7 +1363,7 @@ group TransformROS1FISHObservation(source operations: BackboneElement, target tg
         {
             values.value as polysomie -> tgt.component = create('BackboneElement') as polysomiecomponent then
             {
-                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValue(polysomie, quantity);
+                polysomie -> polysomiecomponent.valueQuantity = create('Quantity') as quantity then MapPercentageValueMP(polysomie, quantity);
                 polysomie -> polysomiecomponent.code = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1386,7 +1382,7 @@ group TransformROS1FISHObservation(source operations: BackboneElement, target tg
 /*---------------------------------------------------------------*/
 
 
-group MapDateOfAssessment(source operations: BackboneElement, source name: string, target tgt: Observation)
+group MapDateOfAssessmentMP(source operations: BackboneElement, source name: string, target tgt: Observation)
 {
     // Date of Assesment
     // choose start time based on type (passed as name)
@@ -1426,7 +1422,7 @@ group MapDateOfAssessment(source operations: BackboneElement, source name: strin
     };
 }
 
-group MapPercentageValue(source src: string, target tgt: Quantity)
+group MapPercentageValueMP(source src: string, target tgt: Quantity)
 {
     src -> tgt.value = src,
             tgt.system = 'http://unitsofmeasure.org',
@@ -1435,7 +1431,7 @@ group MapPercentageValue(source src: string, target tgt: Quantity)
 }
 
 //Phaenotypes
-group MapALKPhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapALKPhaenotypMP(source operations: BackboneElement, target tgt: Observation)
 {
     //Phänotype
     operations.data as data, data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'id_2099'" then
@@ -1472,7 +1468,7 @@ group MapALKPhaenotyp(source operations: BackboneElement, target tgt: Observatio
     };
 }
 
-group MapMETPhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MMapMETPhaenotypMP(source operations: BackboneElement, target tgt: Observation)
 {
     //Phänotype
     operations.data as data, data.values as values where "blockindex = 4 and groupindex = 0 and itemid = 'id_2133'" then
@@ -1509,7 +1505,7 @@ group MapMETPhaenotyp(source operations: BackboneElement, target tgt: Observatio
     };
 }
 
-group MapRETPhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapRETPhaenotypMP(source operations: BackboneElement, target tgt: Observation)
 {
     //Phänotype
     operations.data as data, data.values as values where "blockindex = 5 and groupindex = 0 and itemid = 'id_2184'" then
@@ -1546,7 +1542,7 @@ group MapRETPhaenotyp(source operations: BackboneElement, target tgt: Observatio
     };
 }
 
-group MapROS1Phaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapROS1PhaenotypMP(source operations: BackboneElement, target tgt: Observation)
 {
     //Phänotype
     operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'id_2212'" then
@@ -1585,14 +1581,14 @@ group MapROS1Phaenotyp(source operations: BackboneElement, target tgt: Observati
 
 
 //Codes
-group MapCode(source operations: BackboneElement, source name: string, target tgt: Observation)
+group MapCodeMP(source operations: BackboneElement, source name: string, target tgt: Observation)
 {
     //ALK code
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK');
 }
 
 // Reference
-group SetReferenceToObservation(source operations: BackboneElement, source cishFish: string, source name: string, target tgt: Reference)
+group SetReferenceToObservationCISHMP(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which CISH observation should be referenced
     cishFish where "%cishFish = 'CISH'" then 
@@ -1626,7 +1622,10 @@ group SetReferenceToObservation(source operations: BackboneElement, source cishF
             };
         }; 
     };
+}
 
+group SetReferenceToObservationFISHMP(source operations: BackboneElement, source name: string, target tgt: Reference)
+{
     // Check which FISH observation should be referenced
     cishFish where "%cishFish = 'FISH'" then 
     {

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGS Fusion.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGS Fusion.map
@@ -156,7 +156,7 @@ group TransformDiagnosticReportFusionNGS(source operations: BackboneElement, tar
             };
             values.value where "$this.value != 'Sonstiges'" then
             {   
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFusionNGS(operations, value, reference);
             };
         };
     };
@@ -211,55 +211,55 @@ group CreateObservationsFusionNGS(source operations: BackboneElement, target bun
         // ALK
         values.value where "$this.value = 'ALK'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationALK(operations, observation, composition, section);
+            operations then TransformObservationALKFusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // RET
         values.value where "$this.value = 'RET'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationRET(operations, observation, composition, section);
+            operations then TransformObservationRETFusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // ROS1
         values.value where "$this.value = 'ROS1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationROS1(operations, observation, composition, section);
+            operations then TransformObservationROS1FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // NTRK1
         values.value where "$this.value = 'NTRK1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationNTRK1(operations, observation, composition, section);
+            operations then TransformObservationNTRK1FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // NTRK2
         values.value where "$this.value = 'NTRK2'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationNTRK2(operations, observation, composition, section);
+            operations then TransformObservationNTRK2FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // NTRK3
         values.value where "$this.value = 'NTRK3'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationNTRK3(operations, observation, composition, section);
+            operations then TransformObservationNTRK3FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // FGFR1
         values.value where "$this.value = 'FGFR1'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationFGFR1(operations, observation, composition, section);
+            operations then TransformObservationFGFR1FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // FGFR2
         values.value where "$this.value = 'FGFR2'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationFGFR2(operations, observation, composition, section);
+            operations then TransformObservationFGFR2FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // FGFR3
         values.value where "$this.value = 'FGFR3'" -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
-            operations then TransformObservationFGFR3(operations, observation, composition, section);
+            operations then TransformObservationFGFR3FusionNGS(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');   
         };
         // Sonstiges: create n observation (with n according to repeatindex)
@@ -285,7 +285,7 @@ group CreateObservationsFusionNGS(source operations: BackboneElement, target bun
 }
 
 /* ------------------------------ Observation ALK ----------------------------------- */
-group TransformObservationALK(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationALKFusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -293,7 +293,7 @@ group TransformObservationALK(source operations: BackboneElement, target tgt: Ob
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK', 'ALK');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -418,7 +418,7 @@ group TransformObservationALK(source operations: BackboneElement, target tgt: Ob
 }
 
 /* ------------------------------ Observation RET ----------------------------------- */
-group TransformObservationRET(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationRETFusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -426,7 +426,7 @@ group TransformObservationRET(source operations: BackboneElement, target tgt: Ob
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'RET', 'RET');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -551,7 +551,7 @@ group TransformObservationRET(source operations: BackboneElement, target tgt: Ob
 }
 
 /* ------------------------------ Observation ROS1 ----------------------------------- */
-group TransformObservationROS1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationROS1FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -559,7 +559,7 @@ group TransformObservationROS1(source operations: BackboneElement, target tgt: O
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ROS1', 'ROS1');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -684,7 +684,7 @@ group TransformObservationROS1(source operations: BackboneElement, target tgt: O
 }
 
 /* ------------------------------ Observation NTRK1 ----------------------------------- */
-group TransformObservationNTRK1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationNTRK1FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -692,7 +692,7 @@ group TransformObservationNTRK1(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes', 'NTRK1', 'NTRK1');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -773,7 +773,7 @@ group TransformObservationNTRK1(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Observation NTRK2 ----------------------------------- */
-group TransformObservationNTRK2(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationNTRK2FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -781,7 +781,7 @@ group TransformObservationNTRK2(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'NTRK2', 'NTRK2');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -862,7 +862,7 @@ group TransformObservationNTRK2(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Observation NTRK3 ----------------------------------- */
-group TransformObservationNTRK3(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationNTRK3FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -870,7 +870,7 @@ group TransformObservationNTRK3(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'NTRK3', 'NTRK3');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -951,7 +951,7 @@ group TransformObservationNTRK3(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Observation FGFR1 ----------------------------------- */
-group TransformObservationFGFR1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationFGFR1FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -959,7 +959,7 @@ group TransformObservationFGFR1(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'FGFR1', 'FGFR1');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1040,7 +1040,7 @@ group TransformObservationFGFR1(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Observation FGFR2 ----------------------------------- */
-group TransformObservationFGFR2(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationFGFR2FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -1048,7 +1048,7 @@ group TransformObservationFGFR2(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'FGFR2', 'FGFR2');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1129,7 +1129,7 @@ group TransformObservationFGFR2(source operations: BackboneElement, target tgt: 
 }
 
 /* ------------------------------ Observation FGFR3 ----------------------------------- */
-group TransformObservationFGFR3(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationFGFR3FusionNGS(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
 
@@ -1137,7 +1137,7 @@ group TransformObservationFGFR3(source operations: BackboneElement, target tgt: 
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes', 'FGFR3', 'FGFR3');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1226,7 +1226,7 @@ group TransformObservationSonstigesFusionNGS(source operations: BackboneElement,
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes', 'Sonstiges', 'Sonstiges');
 
     //Fusion NGS
-    operations then MapSOPAssayHerstellerCategoryMethodStatus(operations, tgt);
+    operations then MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1325,7 +1325,7 @@ group TransformObservationSonstigesFusionNGS(source operations: BackboneElement,
 }
 
 /* ------ Items for all the observation created---------- */
-group MapSOPAssayHerstellerCategoryMethodStatus(source operations: BackboneElement, target tgt: Observation)
+group MapSOPAssayHerstellerCategoryMethodStatusFusionNGS(source operations: BackboneElement, target tgt: Observation)
 {
     // Status : Item required on simplifier
     operations ->  tgt.status = cast('final', 'FHIR.code');
@@ -1489,7 +1489,7 @@ group TransformServiceRequestFusionNGS(source operations: BackboneElement, targe
             };
             values.value where "$this.value != 'Sonstiges'" then
             {   
-                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservation(operations, value, reference);
+                values.value as value -> tgt.reasonReference = create('Reference') as reference then SetReferenceToObservationFusionNGS(operations, value, reference);
             };
         };
 
@@ -1538,7 +1538,7 @@ group TransformFusionNGSStatusExtension(source operations: BackboneElement, targ
 }
 
 /*-----------------HELPERS----------------------------*/
-group SetReferenceToObservation(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationFusionNGS(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'ALK'" then 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
@@ -19,7 +19,7 @@ group TransformBundleResistenztestung(source operations: BackboneElement, target
     operations -> biopsieSection.section = create('BackboneElement') as section, section.title = 'resistenztestung', section.code = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/sections', 'resistenztestung') then
     {
         // operations then CreateSpecimenResistenztestung(operations, bundle, composition, section);
-        operations then CreateObservationKrebserkrankung(operations, bundle, composition, section);
+        operations then CreateObservationKrebserkrankungResistenztestung(operations, bundle, composition, section);
         operations then CreateObservationsResistenztestung(operations, bundle, composition, section);
     };
 }
@@ -85,7 +85,7 @@ group TransformSpecimenResistenztestung(source operations: BackboneElement, targ
 
 
 /* ------------------------------ Check whether ObservationKrebserkrankung needs to be created ---------------------------- */ 
-group CreateObservationKrebserkrankung(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement) 
+group CreateObservationKrebserkrankungResistenztestung(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement) 
 {
     // Check whether observation should be created
     let resourceShouldBeCreated = create('Boolean');
@@ -100,13 +100,13 @@ group CreateObservationKrebserkrankung(source operations: BackboneElement, targe
     // Create resource if bool set to true
     operations where "%resourceShouldBeCreated.valueBoolean = true" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
     {
-        operations then TransformObservationKrebserkrankung(operations, observation, composition, section);
+        operations then TransformObservationKrebserkrankungResistenztestung(operations, observation, composition, section);
         operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
     };
 }
 
 /* ------------------------------ Observation Progress/Rezidiv Krebserkrankung ---------------------------- */
-group TransformObservationKrebserkrankung(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationKrebserkrankungResistenztestung(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/progress-relapse';
@@ -164,7 +164,7 @@ group CreateObservationsResistenztestung(source operations: BackboneElement, tar
         {
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationEGFR(operations, observation, composition, section);
+                operations then TransformObservationEGFRResistenztestung(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
             };
         };
@@ -173,7 +173,7 @@ group CreateObservationsResistenztestung(source operations: BackboneElement, tar
         {
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationALK(operations, observation, composition, section);
+                operations then TransformObservationALKResistenztestung(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
             };
         };
@@ -182,7 +182,7 @@ group CreateObservationsResistenztestung(source operations: BackboneElement, tar
         {
             operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
             {
-                operations then TransformObservationROS1(operations, observation, composition, section);
+                operations then TransformObservationROS1Resistenztestung(operations, observation, composition, section);
                 operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
             };
         };
@@ -190,7 +190,7 @@ group CreateObservationsResistenztestung(source operations: BackboneElement, tar
 }
 
 /* ------------------------------ Observation EGFR ---------------------------- */
-group TransformObservationEGFR(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationEGFRResistenztestung(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/tki-resistenz-egfr';
@@ -270,7 +270,7 @@ group TransformObservationEGFR(source operations: BackboneElement, target tgt: O
 }
 
 /* ------------------------------ Observation ALK ---------------------------- */
-group TransformObservationALK(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationALKResistenztestung(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/tki-resistenz-alk';
@@ -337,7 +337,7 @@ group TransformObservationALK(source operations: BackboneElement, target tgt: Ob
 }
 
 /* ------------------------------ Observation ROS1 ---------------------------- */
-group TransformObservationROS1(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationROS1Resistenztestung(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Metadata
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/tki-resistenz-ros1';

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Systemische Therapie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Systemische Therapie.map
@@ -26,15 +26,15 @@ uses "http://hl7.org/fhir/StructureDefinition/Observation" as target
 
 group TransformBundleSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
-    operations then CreateMedicationAdministrationSystemischeTherapie(operations, bundle, composition, section);
-    operations then CreatePatientSystemischeTherapie(operations, bundle, composition, section);
-    operations then CreateEpisodeOfCareSystemischeTherapie(operations, bundle, composition, section);
-    operations then CreateObservationEcogSystemischeTherapie(operations, bundle, composition, section);
-    operations then CreateObservationBestResponseSystemischeTherapie(operations, bundle, composition, section);
+    operations then CreateMedicationAdministrationSY(operations, bundle, composition, section);
+    operations then CreatePatientSY(operations, bundle, composition, section);
+    operations then CreateEpisodeOfCareSY(operations, bundle, composition, section);
+    operations then CreateObservationEcogSY(operations, bundle, composition, section);
+    operations then CreateObservationBestResponseSY(operations, bundle, composition, section);
 }
 
 /* ------------------------------ Check if MedicationAdministration needs to be created ---------------------------- */
-group CreateMedicationAdministrationSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateMedicationAdministrationSY(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     let resourceIsCreated = create('Boolean');
     operations then SetBooleanToFalse(operations, resourceIsCreated);
@@ -65,7 +65,7 @@ group CreateMedicationAdministrationSystemischeTherapie(source operations: Backb
         // if resource is not created yet: call transform
         operations where "%resourceIsCreated.valueBoolean = false" -> bundle.entry as entry, entry.resource = create('MedicationAdministration') as medicationAdministration then 
         {
-            operations then TransformMedicationAdministrationSystemischeTherapie(operations, medicationAdministration, composition, section);
+            operations then TransformMedicationAdministrationSY(operations, medicationAdministration, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(medicationAdministration, '\'MedicationAdministration/\' + $this.id');
             operations then SetBooleanToTrue(operations, resourceIsCreated);
         };
@@ -73,7 +73,7 @@ group CreateMedicationAdministrationSystemischeTherapie(source operations: Backb
 }
 
 /* ------------------------------ MedicationAdministration ---------------------------- */
-group TransformMedicationAdministrationSystemischeTherapie(source operations: BackboneElement, target tgt: MedicationAdministration, target composition: Composition, target section: BackboneElement)
+group TransformMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration, target composition: Composition, target section: BackboneElement)
 {
     // Profile url
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Procedure/nNGM/MedicationAdministration';
@@ -175,7 +175,7 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
                             umgesetzt.valueBoolean = false;
 
                 // Map Grund für die Nichtumsetzung element because it only shows up when 'Nein' is selected
-                operations then MapGrundFurDieNichtumsetzungMedicationAdministration(operations, tgt);
+                operations then MapGrundFurDieNichtumsetzungMedicationAdministrationSY(operations, tgt);
             };
 
             values.value as value where "$this.value = 'N/A' or $this.value = 'N\/A'" then
@@ -259,7 +259,7 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
                             teilnahme.valueBoolean = true;
                 
                 // Map Studienname element because it only shows up when 'Ja' is selected
-                operations then MapStudiennameMedicationAdministration(operations, tgt);
+                operations then MapStudiennameMedicationAdministrationSY(operations, tgt);
             };
 
             values.value as value where "$this.value = 'Nein'" then
@@ -292,7 +292,7 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
         {
             values.value as value where "$this.value = 'yes'" then
             {
-                operations then MapAnderungDesSchemasElementsMedicationAdministration(operations, tgt);
+                operations then MapAnderungDesSchemasElementsMedicationAdministrationSY(operations, tgt);
             };
         };
 
@@ -307,7 +307,7 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
                             option.url = 'option',
                             option.valueBoolean = true;
 
-                operations then MapErhaltungstherapieElementMedicationAdministration(operations, tgt);
+                operations then MapErhaltungstherapieElementMedicationAdministrationSY(operations, tgt);
             };
             
             values.value as value where "$this.value = 'Nein'" then
@@ -339,14 +339,14 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
             {
                 value -> tgt.status = 'on-hold';
                 value -> tgt.statusReason = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/SystemischeTherapieStatusTherapie', 'nebenwirkungen', 'Pause wegen Nebenwirkungen');
-                operations then MapNebenwirkungenGradMedicationAdministration(operations, tgt);
+                operations then MapNebenwirkungenGradMedicationAdministrationSY(operations, tgt);
             };
 
             values.value as value where "$this.value = 'Abbruch wegen Progress'" then
             {
                 value -> tgt.status = 'stopped';
                 value -> tgt.statusReason = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/SystemischeTherapieStatusTherapie', 'progress', 'Progress');
-                operations then MapNebenwirkungenGradMedicationAdministration(operations, tgt);
+                operations then MapNebenwirkungenGradMedicationAdministrationSY(operations, tgt);
             };
 
             values.value as value where "$this.value = 'Ablehnung durch den Patienten'" then
@@ -394,7 +394,7 @@ group TransformMedicationAdministrationSystemischeTherapie(source operations: Ba
 }
 
 /* ------------------------------ MedicationAdministration - Grund für die Nichtumsetzung ---------------------------- */
-group MapGrundFurDieNichtumsetzungMedicationAdministration(source operations: BackboneElement, target tgt: MedicationAdministration)
+group MapGrundFurDieNichtumsetzungMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration)
 {
     // Grund für die Nichtumsetzung: supportingInformation.extension:therapieInformationen.extension:nichtumsetzungGrund
     operations.data as data, data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_2339'" then
@@ -412,7 +412,7 @@ group MapGrundFurDieNichtumsetzungMedicationAdministration(source operations: Ba
 }
 
 /* ------------------------------ MedicationAdministration - Studienname ---------------------------- */
-group MapStudiennameMedicationAdministration(source operations: BackboneElement, target tgt: MedicationAdministration)
+group MapStudiennameMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration)
 {
     // Studienname: extension:studientherapie.extension:studie
     operations.data as data, data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_1244'" then
@@ -431,7 +431,7 @@ group MapStudiennameMedicationAdministration(source operations: BackboneElement,
 }
 
 /* ------------------------------ MedicationAdministration - Elements displayed when Änderung des Schemas is 'Ja' ---------------------------- */
-group MapAnderungDesSchemasElementsMedicationAdministration(source operations: BackboneElement, target tgt: MedicationAdministration)
+group MapAnderungDesSchemasElementsMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration)
 {
     operations.data as data then
     {
@@ -470,7 +470,7 @@ group MapAnderungDesSchemasElementsMedicationAdministration(source operations: B
 }
 
 /* ------------------------------ MedicationAdministration - Elements displayed when Erhaltungstherapie als Option is 'Ja' ---------------------------- */
-group MapErhaltungstherapieElementMedicationAdministration(source operations: BackboneElement, target tgt: MedicationAdministration)
+group MapErhaltungstherapieElementMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration)
 {
     // Für die Erhaltungstherapie verabreichtes Medikament: extension:Erhaltungstherapie.extension:medikament
     operations.data as data, data.values as values where "blockindex = 4 and groupindex = 0 and itemid = 'id_2342'" then
@@ -490,7 +490,7 @@ group MapErhaltungstherapieElementMedicationAdministration(source operations: Ba
 }
 
 /* ------------------------------ MedicationAdministration - Element displayed when Art des therapieendes is 'Abbruch wegen Nebenwirkungen' or 'Pause wegen Nebenwirkungen' ---------------------------- */
-group MapNebenwirkungenGradMedicationAdministration(source operations: BackboneElement, target tgt: MedicationAdministration)
+group MapNebenwirkungenGradMedicationAdministrationSY(source operations: BackboneElement, target tgt: MedicationAdministration)
 {
     // Nebenwirkungen Grad III / Grad IV: extension:nebenwirkung
     operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'id_2343'"then
@@ -522,20 +522,20 @@ group MapNebenwirkungenGradMedicationAdministration(source operations: BackboneE
 }
 
 /* ------------------------------ Check if Patient needs to be created ---------------------------- */
-group CreatePatientSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreatePatientSY(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'id_2344'" then
     {
         operations -> bundle.entry as entry, entry.resource = create('Patient') as patient then 
         {
-            operations then TransformPatientSystemischeTherapie(operations, patient, composition, section);
+            operations then TransformPatientSY(operations, patient, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(patient, '\'Patient/\' + $this.id');
         };
     };
 }
 
 /* ------------------------------ Patient ---------------------------- */
-group TransformPatientSystemischeTherapie(source operations: BackboneElement, target tgt: Patient, target composition: Composition, target section: BackboneElement)
+group TransformPatientSY(source operations: BackboneElement, target tgt: Patient, target composition: Composition, target section: BackboneElement)
 {
     // Profile url
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Patient/nNGM';
@@ -568,20 +568,20 @@ group TransformPatientSystemischeTherapie(source operations: BackboneElement, ta
 }
 
 /* ------------------------------ Check if EpisodeOfCare needs to be created ---------------------------- */
-group CreateEpisodeOfCareSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateEpisodeOfCareSY(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     operations.data as data, data.values as values where "blockindex = 5 and groupindex = 0 and itemid = 'id_1545'" then
     {
         operations -> bundle.entry as entry, entry.resource = create('EpisodeOfCare') as episodeOfCare then 
         {
-            operations then TransformEpisodeOfCareSystemischeTherapie(operations, episodeOfCare, composition, section);
+            operations then TransformEpisodeOfCareSY(operations, episodeOfCare, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(episodeOfCare, '\'EpisodeOfCare/\' + $this.id');
         };
     };
 }
 
 /* ------------------------------ EpisodeOfCare ---------------------------- */
-group TransformEpisodeOfCareSystemischeTherapie(source operations: BackboneElement, target tgt: EpisodeOfCare, target composition: Composition, target section: BackboneElement)
+group TransformEpisodeOfCareSY(source operations: BackboneElement, target tgt: EpisodeOfCare, target composition: Composition, target section: BackboneElement)
 {
     // Profile url
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/EpisodeOfCare/nNGM';
@@ -621,20 +621,20 @@ group TransformEpisodeOfCareSystemischeTherapie(source operations: BackboneEleme
 }
 
 /* ------------------------------ Check if Observation ECOG needs to be created ---------------------------- */
-group CreateObservationEcogSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateObservationEcogSY(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     operations.data as data, data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2415'" then
     {
         operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationEcogSystemischeTherapie(operations, observation, composition, section);
+            operations then TransformObservationEcogSY(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
         };
     };
 }
 
 /* ------------------------------ Observation ECOG ---------------------------- */
-group TransformObservationEcogSystemischeTherapie(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationEcogSY(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Profile url
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/ecog';
@@ -701,7 +701,7 @@ group TransformObservationEcogSystemischeTherapie(source operations: BackboneEle
 }
 
 /* ------------------------------ Check if Observation BestResponse needs to be created ---------------------------- */
-group CreateObservationBestResponseSystemischeTherapie(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
+group CreateObservationBestResponseSY(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
     let resourceIsCreated = create('Boolean');
     operations then SetBooleanToFalse(operations, resourceIsCreated);
@@ -711,7 +711,7 @@ group CreateObservationBestResponseSystemischeTherapie(source operations: Backbo
     {
         operations where "%resourceIsCreated.valueBoolean = false" -> bundle.entry as entry, entry.resource = create('Observation') as observation then 
         {
-            operations then TransformObservationBestResponseSystemischeTherapie(operations, observation, composition, section);
+            operations then TransformObservationBestResponseSY(operations, observation, composition, section);
             operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
             operations then SetBooleanToTrue(operations, resourceIsCreated);
         };
@@ -719,7 +719,7 @@ group CreateObservationBestResponseSystemischeTherapie(source operations: Backbo
 }
 
 /* ------------------------------ Observation BestResponse ---------------------------- */
-group TransformObservationBestResponseSystemischeTherapie(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
+group TransformObservationBestResponseSY(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Profile url
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/best-response';

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -169,18 +169,18 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
         // IHC
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2508'" then
         {
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationIHC(operations, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationIHCVorbefund(operations, value, reference);
         };
         // MP: CISH and FISH
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2509'" then
         {
             let cish = 'CISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMP(operations, cish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMPVorbefund(operations, cish, value, reference);
         };
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2510'" then
         {
             let fish = 'FISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMP(operations, fish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMPVorbefund(operations, fish, value, reference);
         };
         // FusionNGS
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2511'" then
@@ -196,7 +196,7 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
             };
             values.value where "$this.value != 'Sonstiges'" then
             {   
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusion(operations, value, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusionVorbefund(operations, value, reference);
             };
         };
         // FastTrack
@@ -208,13 +208,13 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
                 let EGFFR19 = 'EGFR Exon 19';
                 let EGFFR20 = 'EGFR Exon 20';
                 let EGFFR21 = 'EGFR Exon 21';
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR19, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR20, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, EGFFR21, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR19, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR20, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR21, reference);
             };
             values.value where "$this.value != 'EGFR Exon 19-21'" then
             {
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, value, reference);
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, value, reference);
             };
         };
         // NGS Lung Panel
@@ -393,7 +393,7 @@ group CreateObservationIHCVorbefund(source operations: BackboneElement, target b
 /* ---------------------- Observation BRAF IHC ------------------------ */
 group TransformObservationBRAFIHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
     
     //Code -> BRAF: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'BRAF');
@@ -481,7 +481,7 @@ group TransformObservationBRAFIHCVorbefund(source operations: BackboneElement, t
 /* ---------------------- Observation CK7 IHC ------------------------ */
 group TransformObservationCK7IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {    
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> CK7: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'CK7');
@@ -569,7 +569,7 @@ group TransformObservationCK7IHCVorbefund(source operations: BackboneElement, ta
 /* ---------------------- Observation MIB1 IHC ------------------------ */
 group TransformObservationMIB1IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> MIB1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'MIB1');
@@ -657,7 +657,7 @@ group TransformObservationMIB1IHCVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation NapsinA IHC ---------------------- */
 group TransformObservationNapsinAIHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> Napsin A: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'Napsin A');
@@ -745,7 +745,7 @@ group TransformObservationNapsinAIHCVorbefund(source operations: BackboneElement
 /* ---------------------- Observation P40 IHC ------------------------- */
 group TransformObservationP40IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> P40: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'P40');
@@ -831,7 +831,7 @@ group TransformObservationP40IHCVorbefund(source operations: BackboneElement, ta
 /* ----------------- Observation Synaptophysin IHC -------------------- */
 group TransformObservationSynaptophysinIHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> Synaptophysin: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'Synaptophysin');
@@ -919,7 +919,7 @@ group TransformObservationSynaptophysinIHCVorbefund(source operations: BackboneE
 /* --------------------- Observation TTF1 IHC ------------------------- */
 group TransformObservationTTF1IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {  
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> TTF1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'TTF1');
@@ -1007,7 +1007,7 @@ group TransformObservationTTF1IHCVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation ALK IHC --------------------------- */
 group TransformObservationALKIHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ALK: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK');
@@ -1016,7 +1016,7 @@ group TransformObservationALKIHCVorbefund(source operations: BackboneElement, ta
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationALKDatePhaenotyp(operations, tgt);
+    operations then MapObservationALKDatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -1063,7 +1063,7 @@ group TransformObservationALKIHCVorbefund(source operations: BackboneElement, ta
 /* --------------------- Observation MET IHC --------------------------- */
 group TransformObservationMETIHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> MET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'MET');
@@ -1072,7 +1072,7 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationMETDatePhaenotyp(operations, tgt);
+    operations then MapObservationMETDatePhaenotypVorbefund(operations, tgt);
 
     operations.data as data then
     {
@@ -1149,7 +1149,7 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
 /* --------------------- Observation PD-L1 IHC ------------------------- */
 group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {    
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> PD-L1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes', 'PD-L1');
@@ -1226,7 +1226,7 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C127771');
             };
         };
@@ -1236,7 +1236,7 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'tcell-surface-ratio');
             };
         };
@@ -1252,7 +1252,7 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation ROS1 IHC -------------------------- */
 group TransformObservationROS1IHCVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapIHCStatusCategoryMethod(operations, tgt);
+    operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ROS1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ROS1');
@@ -1261,7 +1261,7 @@ group TransformObservationROS1IHCVorbefund(source operations: BackboneElement, t
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationROS1DatePhaenotyp(operations, tgt);
+    operations then MapObservationROS1DatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -1372,13 +1372,13 @@ group CreateObservationMPVorbefund(source operations: BackboneElement, target bu
 /* --------------------- Observation ALK CISH -------------------------- */
 group TransformObservationALKCISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapCISHStatusCategoryMethod(operations, tgt);
+    operations then MapCISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ALK: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationALKDatePhaenotyp(operations, tgt);
+    operations then MapObservationALKDatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1417,7 +1417,7 @@ group TransformObservationALKCISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1433,7 +1433,7 @@ group TransformObservationALKCISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation MET CISH -------------------------- */
 group TransformObservationMETCISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapCISHStatusCategoryMethod(operations, tgt);
+    operations then MapCISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> MET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'MET');
@@ -1442,7 +1442,7 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationMETDatePhaenotyp(operations, tgt);
+    operations then MapObservationMETDatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -1518,13 +1518,13 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation RET CISH -------------------------- */
 group TransformObservationRETCISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapCISHStatusCategoryMethod(operations, tgt);
+    operations then MapCISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> RET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'RET');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationRETDatePhaenotyp(operations, tgt);
+    operations then MapObservationRETDatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1563,7 +1563,7 @@ group TransformObservationRETCISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1579,13 +1579,13 @@ group TransformObservationRETCISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation ROS1 CISH ------------------------- */
 group TransformObservationROS1CISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapCISHStatusCategoryMethod(operations, tgt);
+    operations then MapCISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ROS1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ROS1');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationROS1DatePhaenotyp(operations, tgt);
+    operations then MapObservationROS1DatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -1624,7 +1624,7 @@ group TransformObservationROS1CISHVorbefund(source operations: BackboneElement, 
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1634,7 +1634,7 @@ group TransformObservationROS1CISHVorbefund(source operations: BackboneElement, 
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1650,7 +1650,7 @@ group TransformObservationROS1CISHVorbefund(source operations: BackboneElement, 
 /* --------------------- Observation ALK FISH -------------------------- */
 group TransformObservationALKFISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFISHStatusCategoryMethod(operations, tgt);
+    operations then MapFISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ALK: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK');
@@ -1659,7 +1659,7 @@ group TransformObservationALKFISHVorbefund(source operations: BackboneElement, t
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationALKDatePhaenotyp(operations, tgt);
+    operations then MapObservationALKDatePhaenotypVorbefund(operations, tgt);
 
     operations.data as data then
     {
@@ -1694,7 +1694,7 @@ group TransformObservationALKFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1704,7 +1704,7 @@ group TransformObservationALKFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1720,7 +1720,7 @@ group TransformObservationALKFISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation MET FISH -------------------------- */
 group TransformObservationMETFISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFISHStatusCategoryMethod(operations, tgt);
+    operations then MapFISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> MET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'MET');
@@ -1729,7 +1729,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp -> 6, 0,id_2132
-    operations then MapObservationMETDatePhaenotyp(operations, tgt);
+    operations then MapObservationMETDatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -1812,7 +1812,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '15-met-ratio');
             };
         };
@@ -1823,7 +1823,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '5-met-ratio');
             };
         };
@@ -1834,7 +1834,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', '4-met-ratio');
             };
         };
@@ -1900,7 +1900,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1916,7 +1916,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation RET FISH -------------------------- */
 group TransformObservationRETFISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFISHStatusCategoryMethod(operations, tgt);
+    operations then MapFISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> RET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'RET');
@@ -1925,7 +1925,7 @@ group TransformObservationRETFISHVorbefund(source operations: BackboneElement, t
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationRETDatePhaenotyp(operations, tgt);
+    operations then MapObservationRETDatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -1961,7 +1961,7 @@ group TransformObservationRETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -1972,7 +1972,7 @@ group TransformObservationRETFISHVorbefund(source operations: BackboneElement, t
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -1988,7 +1988,7 @@ group TransformObservationRETFISHVorbefund(source operations: BackboneElement, t
 /* --------------------- Observation ROS1 FISH ------------------------- */
 group TransformObservationROS1FISHVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFISHStatusCategoryMethod(operations, tgt);
+    operations then MapFISHStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ROS1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ROS1');
@@ -1997,7 +1997,7 @@ group TransformObservationROS1FISHVorbefund(source operations: BackboneElement, 
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
 
     //Date of Assessment,Phaenotyp
-    operations then MapObservationROS1DatePhaenotyp(operations, tgt);
+    operations then MapObservationROS1DatePhaenotypVorbefund(operations, tgt);
 
     // Access data
     operations.data as data then
@@ -2033,7 +2033,7 @@ group TransformObservationROS1FISHVorbefund(source operations: BackboneElement, 
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C70460');
             };
         };
@@ -2043,7 +2043,7 @@ group TransformObservationROS1FISHVorbefund(source operations: BackboneElement, 
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValue(value, quantity);
+                value -> component.valueQuantity = create('Quantity') as quantity then MapPercentageValueVorbefund(value, quantity);
                 value -> component.code          = cc('http://ncit.nci.nih.gov', 'C36331');
             };
         };
@@ -2146,13 +2146,13 @@ group CreateObservationFusionNGSVorbefund(source operations: BackboneElement, ta
 /* ------------------ Observation ALK FusionNGS ------------------------ */
 group TransformObservationALKFusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ALK: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ALK');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationALKDatePhaenotyp(operations, tgt);
+    operations then MapObservationALKDatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -2237,13 +2237,13 @@ group TransformObservationALKFusionNGSVorbefund(source operations: BackboneEleme
 /* ------------------ Observation RET FusionNGS ------------------------ */
 group TransformObservationRETFusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> RET: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'RET');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationRETDatePhaenotyp(operations, tgt);
+    operations then MapObservationRETDatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -2328,13 +2328,13 @@ group TransformObservationRETFusionNGSVorbefund(source operations: BackboneEleme
 /* ---------------- Observation ROS1 FusionNGS ------------------------- */
 group TransformObservationROS1FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> ROS1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'ROS1');
 
     //Date of Assessment, Phaenotyp
-    operations then MapObservationROS1DatePhaenotyp(operations, tgt);
+    operations then MapObservationROS1DatePhaenotypVorbefund(operations, tgt);
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -2419,7 +2419,7 @@ group TransformObservationROS1FusionNGSVorbefund(source operations: BackboneElem
 /* ----------------- Observation NTRK1 FusionNGS ----------------------- */
 group TransformObservationNTRK1FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> NTRK1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'NTRK1');
@@ -2503,7 +2503,7 @@ group TransformObservationNTRK1FusionNGSVorbefund(source operations: BackboneEle
 /* ---------------- Observation NTRK2 FusionNGS ------------------------ */
 group TransformObservationNTRK2FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> NTRK2: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'NTRK2');
@@ -2587,7 +2587,7 @@ group TransformObservationNTRK2FusionNGSVorbefund(source operations: BackboneEle
 /* ----------------- Observation NTRK3 FusionNGS ----------------------- */
 group TransformObservationNTRK3FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> NTRK3: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'NTRK3');
@@ -2671,7 +2671,7 @@ group TransformObservationNTRK3FusionNGSVorbefund(source operations: BackboneEle
 /* ---------------- Observation FGFR1 FusionNGS ------------------------ */
 group TransformObservationFGFR1FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> FGFR1: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'FGFR1');
@@ -2755,7 +2755,7 @@ group TransformObservationFGFR1FusionNGSVorbefund(source operations: BackboneEle
 /* ----------------- Observation FGFR2 FusionNGS ----------------------- */
 group TransformObservationFGFR2FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> FGFR2: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'FGFR2');
@@ -2840,7 +2840,7 @@ group TransformObservationFGFR2FusionNGSVorbefund(source operations: BackboneEle
 /* ----------------- Observation FGFR3 FusionNGS ----------------------- */
 group TransformObservationFGFR3FusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> FGFR3: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'FGFR3');
@@ -2924,7 +2924,7 @@ group TransformObservationFGFR3FusionNGSVorbefund(source operations: BackboneEle
 /* ---------------- Observation Sonstiges FusionNGS -------------------- */
 group TransformObservationSonstigesFusionNGSVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement, target index: RepeatIndex)
 { 
-    operations then MapFusionNGSStatusCategoryMethod(operations, tgt);
+    operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> Sonstiges: Item required in Simplifier
     operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'Sonstiges');
@@ -3070,7 +3070,7 @@ group CreateObservationFastTrackVorbefund(source operations: BackboneElement, ta
 /* ------------ Observation BRAF Exon 15 Fast Track -------------------- */
 group TransformObservationBRAFExon15Vorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 { 
-    operations then MapFastTrackStatusCategoryMethod(operations, tgt);
+    operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C158854', 'BRAF Exon 15 Mutation');
@@ -3131,13 +3131,13 @@ group TransformObservationBRAFExon15Vorbefund(source operations: BackboneElement
 /* ------------ Observation EGFR Exon 19 Fast Track -------------------- */
 group TransformObservationEGFRExon19Vorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 { 
-    operations then MapFastTrackStatusCategoryMethod(operations, tgt);
+    operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
     src -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128662','EGFR Exon 19 Mutation');
 
     //Date of Assessment, Assay, Hersteller
-    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921(operations, tgt);
+    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -3187,13 +3187,13 @@ group TransformObservationEGFRExon19Vorbefund(source operations: BackboneElement
 /* ------------ Observation EGFR Exon 20 Fast Track -------------------- */
 group TransformObservationEGFRExon20Vorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 { 
-    operations then MapFastTrackStatusCategoryMethod(operations, tgt);
+    operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
     src -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128663','EGFR Exon 20 Mutation');
 
     //Date of Assessment, Assay, Hersteller
-    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921(operations, tgt);
+    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -3245,13 +3245,13 @@ group TransformObservationEGFRExon20Vorbefund(source operations: BackboneElement
 /* ------------ Observation EGFR Exon 21 Fast Track -------------------- */
 group TransformObservationEGFRExon21Vorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 { 
-    operations then MapFastTrackStatusCategoryMethod(operations, tgt);
+    operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
     src -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128666','EGFR Exon 21 Mutation');
 
     //Date of Assessment, Assay, Hersteller
-    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921(operations, tgt);
+    operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -3303,7 +3303,7 @@ group TransformObservationEGFRExon21Vorbefund(source operations: BackboneElement
 /* -------------- Observation KRAS Exon Fast Track --------------------- */
 group TransformObservationKRASExon2Vorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 { 
-    operations then MapFastTrackStatusCategoryMethod(operations, tgt);
+    operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
     operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C135715','KRAS Exon 2 Mutation');
@@ -3570,14 +3570,14 @@ group TransformObservationNGSPanelVorbefund(source operations: BackboneElement, 
 /*------------------------------------------------------------------------------
                              HELPERS                                   
 ------------------------------------------------------------------------------*/
-group MapPercentageValue(source src: string, target tgt: Quantity)
+group MapPercentageValueVorbefund(source src: string, target tgt: Quantity)
 {
     src -> tgt.value   = src,
             tgt.system = 'http://unitsofmeasure.org',
             tgt.unit   = 'percentage',
             tgt.code   = '%';
 }
-group MapStatusCategory(source operations: BackboneElement, target tgt: Observation)
+group MapStatusCategoryVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     // Status: Item required in Simplifier
     operations -> tgt.status = cast('final', 'FHIR.code');
@@ -3585,16 +3585,16 @@ group MapStatusCategory(source operations: BackboneElement, target tgt: Observat
     //category: Item required in Simplifier
     operations -> tgt.category = cc('http://terminology.hl7.org/CodeSystem/observation-category', 'laboratory');
 }
-group MapIHCStatusCategoryMethod(source operations: BackboneElement, target tgt: Observation)
+group MapIHCStatusCategoryMethodVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc';
 
-    operations then MapStatusCategory(operations, tgt);
+    operations then MapStatusCategoryVorbefund(operations, tgt);
 
     //Methode IHC
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23020');
 }
-group MapObservationALKDatePhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapObservationALKDatePhaenotypVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations.data as data then
     {
@@ -3638,7 +3638,7 @@ group MapObservationALKDatePhaenotyp(source operations: BackboneElement, target 
         };
     };
 }
-group MapObservationMETDatePhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapObservationMETDatePhaenotypVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations.data as data then
     {
@@ -3682,7 +3682,7 @@ group MapObservationMETDatePhaenotyp(source operations: BackboneElement, target 
         };
     };
 }
-group MapObservationRETDatePhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapObservationRETDatePhaenotypVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations.data as data then
     {
@@ -3726,7 +3726,7 @@ group MapObservationRETDatePhaenotyp(source operations: BackboneElement, target 
         };
     };
 }
-group MapObservationROS1DatePhaenotyp(source operations: BackboneElement, target tgt: Observation)
+group MapObservationROS1DatePhaenotypVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations.data as data then
     {
@@ -3770,43 +3770,43 @@ group MapObservationROS1DatePhaenotyp(source operations: BackboneElement, target
         };
     };
 }
-group MapCISHStatusCategoryMethod(source operations: BackboneElement, target tgt: Observation)
+group MapCISHStatusCategoryMethodVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish';
     
-    operations then MapStatusCategory(operations, tgt);
+    operations then MapStatusCategoryVorbefund(operations, tgt);
 
     //Methode CISH
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C23022');
 }
-group MapFISHStatusCategoryMethod(source operations: BackboneElement, target tgt: Observation)
+group MapFISHStatusCategoryMethodVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish';
 
-    operations then MapStatusCategory(operations, tgt);
+    operations then MapStatusCategoryVorbefund(operations, tgt);
 
     //Methode FISH
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C17563');
 }
-group MapFusionNGSStatusCategoryMethod(source operations: BackboneElement, target tgt: Observation)
+group MapFusionNGSStatusCategoryMethodVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression';
     
-    operations then MapStatusCategory(operations, tgt);
+    operations then MapStatusCategoryVorbefund(operations, tgt);
 
     //Methode FusionNGS
     operations -> tgt.method = cc('http://ncit.nci.nih.gov', 'C101293');
 }
-group MapFastTrackStatusCategoryMethod(source operations: BackboneElement, target tgt: Observation)
+group MapFastTrackStatusCategoryMethodVorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack';
     
-    operations then MapStatusCategory(operations, tgt);
+    operations then MapStatusCategoryVorbefund(operations, tgt);
 
     //Methode Fast Track
     operations -> tgt.method = cc('http://ncit.nci.nih.gov','C101293');
 }
-group MapObservationFastTrackDateAssayHerstellerEGFREXO1921(source operations: BackboneElement, target tgt: Observation)
+group MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(source operations: BackboneElement, target tgt: Observation)
 {
     operations.data as data then
     {
@@ -3836,7 +3836,7 @@ group MapObservationFastTrackDateAssayHerstellerEGFREXO1921(source operations: B
         };
     };
 }
-group SetReferenceToObservationIHC(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationIHCVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'BRAF'" then 
@@ -3927,7 +3927,7 @@ group SetReferenceToObservationIHC(source operations: BackboneElement, source na
         };     
     };
 }
-group SetReferenceToObservationMP(source operations: BackboneElement, source cishFish: string, source name: string, target tgt: Reference)
+group SetReferenceToObservationMPVorbefund(source operations: BackboneElement, source cishFish: string, source name: string, target tgt: Reference)
 {
     // Check which CISH observation should be referenced
     cishFish where "%cishFish = 'CISH'" then 
@@ -3995,7 +3995,7 @@ group SetReferenceToObservationMP(source operations: BackboneElement, source cis
         };
     };
 }
-group SetReferenceToObservationNGSFusion(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationNGSFusionVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'ALK'" then 
@@ -4062,7 +4062,7 @@ group SetReferenceToObservationNGSFusion(source operations: BackboneElement, sou
         };
     };
 }
-group SetReferenceToObservationFastTrack(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationFastTrackVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which observation should be referenced
     name where "%name = 'BRAF Exon 15'" then 


### PR DESCRIPTION
### Add suffixes to each group

Now all groups in each FHIR-to-CDS map has a unique name. This is essential correct transforming.
Otherwise groups like TransformObservationROS1 can be found in IHC and FS resulting in errors when transforming data.


**Changes**

- Rename each group of each (FHIR-to-CDS) map