### PR TITLE
Feature/fix vorbefund

### DIFF
--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Fast Track.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Fast Track.map
@@ -69,7 +69,7 @@ group TransformDiagnosticReportFastTrack(source operations: BackboneElement, tar
         // Observations
         data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'id_2512'" then
         {
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrack(operations, value, tgt);
+            values.value as value then SetReferenceToObservationFastTrack(operations, value, tgt);
         };
 
         // Organization

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
@@ -111,6 +111,9 @@ group TransformDiagnosticReportHistologie(source operations: BackboneElement, ta
     // code
     operations -> tgt.code = cc('http://loinc.org', '50398-7'); 
 
+    // Subject
+    operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
+
     // Access data
     operations.data as data then
     {
@@ -121,9 +124,15 @@ group TransformDiagnosticReportHistologie(source operations: BackboneElement, ta
             values.value as value -> section.entry = create('Reference') as untersuchung, untersuchung.reference = evaluate(value, '\'DiagnosticReport/\' + $this');
         };
 
-        // Reference Patient
-        operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
-
+        //Untersuchungs-ID
+        data.values as values where "blockindex = 5 and groupindex = 0 and itemid = 'assessment_id'" then
+        {
+            values.value as id -> tgt.identifier = create('Identifier') as befundNummer,
+                                                          befundNummer.system = 'http://uk-koeln.de/NamingSystem/nNGM/befundnummer',
+                                                          befundNummer.value = id;
+        };
+        
+        //Referenzen
         // Reference Specimen
         data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
         {
@@ -134,16 +143,7 @@ group TransformDiagnosticReportHistologie(source operations: BackboneElement, ta
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'uuid_nngm_histologie'" then
         {
             values.value as value -> tgt.result = create('Reference') as result, result.reference = evaluate(value, '\'Observation/\' + $this');
-        };
-
-        //Referenzen
-        //Untersuchungs-ID
-        data.values as values where "blockindex = 5 and groupindex = 0 and itemid = 'assessment_id'" then
-        {
-            values.value as id -> tgt.identifier = create('Identifier') as befundNummer,
-                                                          befundNummer.system = 'http://uk-koeln.de/NamingSystem/nNGM/befundnummer',
-                                                          befundNummer.value = id;
-        };
+        }; 
     };
 }
 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
@@ -202,7 +202,7 @@ group TransformObservationHistologie(source operations: BackboneElement, target 
         // Klassifikation -> component:klassifikation.valueCodeableConcept
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_1658'" then
         {
-            values.value as value -> tgt.component = create('CodeableConcept') as klassifikation,
+            values.value as value -> tgt.component = create('BackboneElement') as klassifikation,
                                                     klassifikation.code = cc('http://ncit.nci.nih.gov', 'C25161'),
                                                     klassifikation.valueCodeableConcept as vcc,
                                                     vcc.coding as coding,

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Histologie.map
@@ -178,7 +178,7 @@ group CreateObservationHistologie(source operations: BackboneElement, target bun
 group TransformObservationHistologie(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
     // Resource information
-    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie';
+    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie';
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGS Fusion.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGS Fusion.map
@@ -1227,7 +1227,8 @@ group TransformObservationSonstigesFusionNGS(source operations: BackboneElement,
             values.value as ersterfusionspartner -> tgt.component = create('BackboneElement') as componentErsterFusionspartner then
             {
                 ersterfusionspartner -> componentErsterFusionspartner.valueString = ersterfusionspartner;
-                ersterfusionspartner -> componentErsterFusionspartner.code = cc('http://loinc.org', '48018-6');
+                ersterfusionspartner -> componentErsterFusionspartner.code = cc('http://loinc.org', '48018-6') as codeableConcept,
+                                            codeableConcept.coding = c('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'erster-fusionspartner');
             };
         };
 
@@ -1237,7 +1238,8 @@ group TransformObservationSonstigesFusionNGS(source operations: BackboneElement,
             values.value as fusionspartner -> tgt.component = create('BackboneElement') as componentFusionspartner then
             {
                 fusionspartner -> componentFusionspartner.valueString = fusionspartner;
-                fusionspartner -> componentFusionspartner.code = cc('http://loinc.org', '48018-6');
+                fusionspartner -> componentFusionspartner.code = cc('http://loinc.org', '48018-6') as codeableConcept,
+                                        codeableConcept.coding = c('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'zweiter-fusionspartner');
             };
         };
         //Anzahl der Fusionsreads

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
@@ -1,10 +1,6 @@
 /// version = 0.1
 /// title = "NGS Lung Panel"
 
-/*
-TODO  
-    - [Observation] adding bundle.entry.request is currently commented out due to a missing repeatindex in the CDS-Export which would result in an error for evaluate()
-*/
 
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_NGSLungPanelFHIR" = nNGM_Mapping_NGSLungPanelFHIR
 
@@ -225,7 +221,7 @@ group CreateObservationNGSPanel(source operations: BackboneElement, target bundl
         operations -> bundle.entry as entry, entry.resource = create('Observation') as observation then
         {
             operations then TransformObservationNGSLungPanel(operations, observation, composition, section, index);
-            // operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
+            operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(observation, '\'Observation/\' + $this.id');
         };
         operations then IncrementSectionIndex(operations, index);
     };

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
@@ -87,13 +87,6 @@ group TransformDiagnosticReportNGSLungPanel(source operations: BackboneElement, 
             };
         };
 
-        operations then InitSectionIndex(operations, index); // (re)set index to 0
-        data.values as values where "blockindex = 4 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel_research'" then
-        {
-            values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
-            operations then IncrementSectionIndex(operations, index);
-        };
-
         // Organization
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'uuid_organizationalunit'" then
         {

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-NGSLungPanel.map
@@ -44,6 +44,8 @@ group CreateDiagnosticReportNGSLungPanel(source operations: BackboneElement, tar
 /* -------------------------- DiagnosticReport ------------------------ */
 group TransformDiagnosticReportNGSLungPanel(source operations: BackboneElement, target tgt: DiagnosticReport, target composition: Composition, target section: BackboneElement, target index: RepeatIndex)
 {
+    operations then InitSectionIndex(operations, index); // (re)set index to 0
+
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund';
 
     // status
@@ -77,7 +79,6 @@ group TransformDiagnosticReportNGSLungPanel(source operations: BackboneElement, 
         // Specimen is set in Master.map
 
         // Observations
-        operations then InitSectionIndex(operations, index); // (re)set index to 0
         data.values as values where "blockindex = 4 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel'" then
         {
             values.value as value where "unit.exists().not()" then // to not use the unit = _research uuid value element

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -24,7 +24,7 @@ group TransformBundleVorbefundFHIR(source operations: BackboneElement, target bu
         operations then CreateObservationIHCVorbefund(operations, bundle, composition, section);
         operations then CreateObservationMPVorbefund(operations, bundle, composition, section);
         operations then CreateObservationFastTrackVorbefund(operations, bundle, composition, section);
-        // operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
+        operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
         
         // there may be more than 1 instance of some Observation (Sonstiges and Lung Panel), thus an index is needed to reference (and create) the correct observation
         operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
@@ -3210,7 +3210,7 @@ group TransformDeviceNGSPanelVorbefund(source operations: BackboneElement, targe
     operations -> tgt.id = uuid();
     operations -> section.entry = create('Reference') as device, device.reference = evaluate(tgt, '\'Device/\' + $this.id');
     
-    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device';
+    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device/nNGM/ngs-panel';
     
     // Access data
     operations.data as data then

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -100,18 +100,10 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund';
 
     // status: Item required on simplifier
-    operations ->  tgt.status as status, 
-                    status.extension as dataAbsentReason, 
-                    dataAbsentReason.url       = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
-                    dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
-    // operations -> tgt.status = 'final';
+    operations -> tgt.status = 'final';
 
     // code: Item required on simplifier
-    operations ->  tgt.code as code, 
-                    code.extension as dataAbsentReason, 
-                    dataAbsentReason.url       = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
-                    dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
-    // operations -> tgt.code = cc('http://loinc.org', '50398-7'); 
+    operations -> tgt.code = cc('http://loinc.org', '50398-7'); 
 
     // Subject 
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -138,7 +130,7 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
         // Befunddatum
         data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_1653'" then
         {
-            values.value as value -> tgt.issued =  dateOp(value, 'date');
+            values.value as effectiveDT -> tgt.effectiveDateTime = dateOp(effectiveDT, 'date');
         };
 
         // Referenzen

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -1,17 +1,10 @@
 /// version = 0.1
 /// title = "nNGM_Mapping_VorbefundFHIR"
+
 /*
     TODO 
-    - repeatindex is off by +1
-    - creation and reference to Specimen is commented out until clarification 
+    - reference to Specimen is commented out until clarification 
     - Device: has no uuid and therefore cannot be referenced in BservationNGSPanel
-    
-    repeatindex is off by +1
-    Specimen is currently commented out until clarification.
-    NGSPanel: clarify what uuid_ngsPanel_research is meant for
-    FastTrack: what to do with uuid_fasttrack_egfr1921?
-    Device: has no uuid and therefore cannot be referenced in ObservationNGSPanel
-
 */
 
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundFHIR" = nNGM_Mapping_VorbefundFHIR
@@ -27,34 +20,27 @@ group TransformBundleVorbefundFHIR(source operations: BackboneElement, target bu
 {
     operations -> biopsieSection.section = create('BackboneElement') as section, section.title = 'vorbefund', section.code = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/sections', 'vorbefund') then
     {
-        // operations then CreateSpecimenVorbefund(operations, bundle, composition, section);
+        operations then CreateSpecimenVorbefund(operations, bundle, composition, section);
+        operations then CreateObservationHistologieVorbefund(operations, bundle, composition, section);
         operations then CreateObservationIHCVorbefund(operations, bundle, composition, section);
         operations then CreateObservationMPVorbefund(operations, bundle, composition, section);
-        operations then CreateObservationFastTrackVorbefund(operations, bundle, composition, section);
-        operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
+        // operations then CreateObservationFastTrackVorbefund(operations, bundle, composition, section);
+        // operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
         
         // there may be more than 1 instance of some Observation (Sonstiges and Lung Panel), thus an index is needed to reference (and create) the correct observation
-        operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
-        operations then CreateObservationFusionNGSVorbefund(operations, bundle, composition, section, index);  
-        operations then CreateObservationNGSPanelVorbefund(operations, bundle, composition, section, index);  
+        // operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
+        // operations then CreateObservationFusionNGSVorbefund(operations, bundle, composition, section, index);  
+        // operations then CreateObservationNGSPanelVorbefund(operations, bundle, composition, section, index);  
     };
 }
 
 /* ------------------------------ Specimen ---------------------------- */
 group CreateSpecimenVorbefund(source operations: BackboneElement, target bundle: Bundle, target composition: Composition, target section: BackboneElement)
 {
-    let resourceIsCreated = create('Boolean');
-    operations then SetBooleanToFalse(operations, resourceIsCreated);
-
-    operations.data as data, data.values as values where "blockindex = 27 and groupindex = 0 and itemid = 'id_1601'
-                                                        or blockindex = 0 and groupindex = 0 and itemid = 'id_2471'" then
+    operations.data as data, data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_2471'" -> bundle.entry as entry, entry.resource = create('Specimen') as specimen then
     {
-        operations where "%resourceIsCreated.valueBoolean = false" -> bundle.entry as entry, entry.resource = create('Specimen') as specimen then 
-        {
-            operations then TransformSpecimenVorbefund(operations, specimen, composition, section);
-            operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(specimen, '\'Specimen/\' + $this.id');
-            operations then SetBooleanToTrue(operations, resourceIsCreated);
-        };     
+        operations then TransformSpecimenVorbefund(operations, specimen, composition, section);
+        operations -> entry.request as request, request.method = 'PUT', request.url = evaluate(specimen, '\'Specimen/\' + $this.id');
     };    
 }
 /* ------------------------------ Specimen ---------------------------- */
@@ -67,7 +53,7 @@ group TransformSpecimenVorbefund(source operations: BackboneElement, target tgt:
                                                                     snomedGlobalPatientSet.version = 'http://snomed.info/sct/900000000000207008',
                                                                     snomedGlobalPatientSet.code    = 'UNKNOWN';
 
-    // Sbject 
+    // Subject 
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
     
     // Access data
@@ -80,9 +66,20 @@ group TransformSpecimenVorbefund(source operations: BackboneElement, target tgt:
             values.value as value -> section.entry = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
         };
 
+        // Eingang des Tumormaterials am nNGM-Standort
         data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_2471'" then
         {
             values.value as value -> tgt.receivedTime = dateOp(value, 'dateTime');
+        };
+
+        // Type: Item required on simplifier
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_2517'" then
+        {
+           values.value as value -> tgt.type as type, type.coding = create('Coding') as snomedGlobalPatientSet, snomedGlobalPatientSet.system = 'http://snomed.info/sct',
+                                                                                        snomedGlobalPatientSet.version = 'http://snomed.info/sct/900000000000207008',
+                                                                                        snomedGlobalPatientSet.code as code, code.extension as dataAbsentReason,
+                                                                                        dataAbsentReason.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
+                                                                                        dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
         };
     };
 }
@@ -245,14 +242,14 @@ group CreateObservationHistologieVorbefund(source operations: BackboneElement, t
     };          
 }
 /* ---------------------- ObservationHistologie ----------------------- */
-group TransformObservationHistologieVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement, target index: RepeatIndex)
+group TransformObservationHistologieVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie';
+    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie';
     
-    //status: Item required on simplifier
+    // Status 
     operations ->  tgt.status = cast('final', 'FHIR.code');
 
-    //code: Item required on simplifier
+    // Code
     operations -> tgt.code = cc('http://ncit.nci.nih.gov','C18000');
 
     // Subject
@@ -422,7 +419,7 @@ group TransformObservationBRAFIHCVorbefund(source operations: BackboneElement, t
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -451,25 +448,21 @@ group TransformObservationBRAFIHCVorbefund(source operations: BackboneElement, t
             };
         };
 
-        //Ergebnis 
-        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'braf_ihc_result'" then
+        // Ergebnis
+        data.values as values where "blockindex = 4 and groupindex = 0 and itemid = 'braf_ihc_result'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
+        // Antikörper
+        data.values as values where "blockindex = 4 and groupindex = 0 and itemid = 'braf_ihc_ab'" then
+        {
+            values.value as antikoerper -> tgt.component = create('BackboneElement') as componentAntikoerper then
+            {
+                antikoerper -> componentAntikoerper.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/ihc-antikoerper', antikoerper);
+                antikoerper -> componentAntikoerper.code = cc('http://ncit.nci.nih.gov', 'C16295');
+            };
+        };
         // Referenzen
         // Specimen
         // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
@@ -510,7 +503,7 @@ group TransformObservationCK7IHCVorbefund(source operations: BackboneElement, ta
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -539,23 +532,10 @@ group TransformObservationCK7IHCVorbefund(source operations: BackboneElement, ta
             };
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 5 and groupindex = 0 and itemid = 'id_2045'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -598,7 +578,7 @@ group TransformObservationMIB1IHCVorbefund(source operations: BackboneElement, t
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -627,23 +607,10 @@ group TransformObservationMIB1IHCVorbefund(source operations: BackboneElement, t
             };
         };
         
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 7 and groupindex = 0 and itemid = 'id_2063'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -686,7 +653,7 @@ group TransformObservationNapsinAIHCVorbefund(source operations: BackboneElement
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -715,23 +682,10 @@ group TransformObservationNapsinAIHCVorbefund(source operations: BackboneElement
             };
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 14 and groupindex = 0 and itemid = 'id_2072'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -768,12 +722,13 @@ group TransformObservationP40IHCVorbefund(source operations: BackboneElement, ta
         {
             values.value as effectiveDT -> tgt.effectiveDateTime = dateOp(effectiveDT, 'date');
         };
+
         //Phänotyp -> phaenotyp component
         data.values as values where "blockindex = 15 and groupindex = 0 and itemid = 'id_2074'" then
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -801,23 +756,11 @@ group TransformObservationP40IHCVorbefund(source operations: BackboneElement, ta
                 };
             };
         };
-        //Ergebnis 
+
+        // Ergebnis
         data.values as values where "blockindex = 15 and groupindex = 0 and itemid = 'id_2079'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -860,7 +803,7 @@ group TransformObservationSynaptophysinIHCVorbefund(source operations: BackboneE
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -889,23 +832,10 @@ group TransformObservationSynaptophysinIHCVorbefund(source operations: BackboneE
             };
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 18 and groupindex = 0 and itemid = 'id_2088'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -948,7 +878,7 @@ group TransformObservationTTF1IHCVorbefund(source operations: BackboneElement, t
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -977,23 +907,10 @@ group TransformObservationTTF1IHCVorbefund(source operations: BackboneElement, t
             };
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 19 and groupindex = 0 and itemid = 'id_2097'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -1028,28 +945,10 @@ group TransformObservationALKIHCVorbefund(source operations: BackboneElement, ta
             values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'id_2106'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'fraglich'" then 
-            {
-                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -1083,28 +982,10 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
             values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'id_2139'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'fraglich'" then 
-            {
-                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         //Klassifikation -> Klassifikation component
@@ -1124,7 +1005,7 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
             {
                 value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueBoolean	 = cast(true, 'FHIR.boolean');
+                    value -> component.valueBoolean	 = 'true';
                     value -> component.code          = cc('http://ncit.nci.nih.gov', 'C129474');
                 };
             };
@@ -1132,7 +1013,7 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
             {
                 value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueBoolean	 = cast(false, 'FHIR.boolean');
+                    value -> component.valueBoolean	 = 'false';
                     value -> component.code          = cc('http://ncit.nci.nih.gov', 'C129474');
                 };
             };
@@ -1178,7 +1059,7 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -1207,18 +1088,10 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
             };
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 16 and groupindex = 0 and itemid = 'id_2180'" then
         {
-            values.value as value where "value = 'auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         //Menge der Tumorzellen (% positive Tumorzellen TPS) -> menge-tumorzellen component
@@ -1273,28 +1146,10 @@ group TransformObservationROS1IHCVorbefund(source operations: BackboneElement, t
             values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
         };
 
-        //Ergebnis 
+        // Ergebnis
         data.values as values where "blockindex = 17 and groupindex = 0 and itemid = 'id_2219'" then
         {
-            values.value as value where "value = 'positiv'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
-            };
-
-            values.value as value where "value = 'fraglich'" then 
-            {
-                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
-            };
-
-            values.value as value where "value = 'negativ'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
-            };
+            values.value as value -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', value, value);
         };
 
         // Referenzen
@@ -3381,6 +3236,7 @@ group TransformDeviceNGSPanelVorbefund(source operations: BackboneElement, targe
 {
     // TODO: may need to be replaced by uuid_device
     operations -> tgt.id = uuid();
+    operations -> section.entry = create('Reference') as device, device.reference = evaluate(tgt, '\'Device/\' + $this.id');
     
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device';
     
@@ -3574,7 +3430,7 @@ group MapPercentageValueVorbefund(source src: string, target tgt: Quantity)
 {
     src -> tgt.value   = src,
             tgt.system = 'http://unitsofmeasure.org',
-            tgt.unit   = 'percentage',
+            tgt.unit   = '%',
             tgt.code   = '%';
 }
 group MapStatusCategoryVorbefund(source operations: BackboneElement, target tgt: Observation)
@@ -3608,7 +3464,7 @@ group MapObservationALKDatePhaenotypVorbefund(source operations: BackboneElement
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -3652,7 +3508,7 @@ group MapObservationMETDatePhaenotypVorbefund(source operations: BackboneElement
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -3696,7 +3552,7 @@ group MapObservationRETDatePhaenotypVorbefund(source operations: BackboneElement
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {
@@ -3740,7 +3596,7 @@ group MapObservationROS1DatePhaenotypVorbefund(source operations: BackboneElemen
         {
             values.value where "%tgt.component.code.where(coding.code = 'C16977').exists().not()" then
             {
-                values.value as phaenotyp where "value = 'Expresssion'" then
+                values.value as phaenotyp where "value = 'Expression'" then
                 {
                     phaenotyp->tgt.component = create('BackboneElement') as componentPhaenotyp then
                     {

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -29,8 +29,8 @@ group TransformBundleVorbefundFHIR(source operations: BackboneElement, target bu
         
         // there may be more than 1 instance of some Observation (Sonstiges and Lung Panel), thus an index is needed to reference (and create) the correct observation
         operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
-        // operations then CreateObservationFusionNGSVorbefund(operations, bundle, composition, section, index);  
-        // operations then CreateObservationNGSPanelVorbefund(operations, bundle, composition, section, index);  
+        operations then CreateObservationFusionNGSVorbefund(operations, bundle, composition, section, index);  
+        operations then CreateObservationNGSPanelVorbefund(operations, bundle, composition, section, index);  
     };
 }
 
@@ -105,9 +105,6 @@ group CreateDiagnosticReportVorbefund(source operations: BackboneElement, target
 /* ------------------------- DiagnosticReport ------------------------- */
 group TransformDiagnosticReportVorbefund(source operations: BackboneElement, target tgt: DiagnosticReport, target composition: Composition, target section: BackboneElement, target index: RepeatIndex)
 {
-    // since there can be more than 1 instance of the NGS Lung Panel and Sonstiges (FusionNGS) we need an index to assign the corresponding data to each observation
-    operations then InitSectionIndex(operations, index); // (re)set index to 0
-
     operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund';
 
     // status: Item required on simplifier
@@ -179,35 +176,40 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
         {
             values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFISHMPVorbefund(operations, value, reference);
         };
-        // // FusionNGS
-        // data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2511'" then
-        // {
-        //     // if Sonstiges: create n observation references (with n according to repeatindex)
-        //     values.value where "$this.value = 'Sonstiges'" then
-        //     {
-        //         operations.data as data, data.values as values where "blockindex = 21 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsFusionExpression_sonstiges'" then
-        //         {
-        //             values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
-        //             operations then IncrementSectionIndex(operations, index);
-        //         };
-        //     };
-        //     values.value where "$this.value != 'Sonstiges'" then
-        //     {   
-        //         values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusionVorbefund(operations, value, reference);
-        //     };
-        // };
+        // FusionNGS
+        operations then InitSectionIndex(operations, index); // (re)set index to 0
+        data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2511'" then
+        {
+            // if Sonstiges: create n observation references (with n according to repeatindex)
+            values.value where "$this.value = 'Sonstiges'" then
+            {
+                operations.data as data, data.values as values where "blockindex = 21 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsFusionExpression_sonstiges'" then
+                {
+                    values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+                    operations then IncrementSectionIndex(operations, index);
+                };
+            };
+            values.value where "$this.value != 'Sonstiges'" then
+            {   
+                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusionVorbefund(operations, value, reference);
+            };
+        };
         // FastTrack
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2512'" then
         {
             values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, value, tgt);
         };
-        // // NGS Lung Panel
-        // operations then InitSectionIndex(operations, index); // (re)set index to 0
-        // data.values as values where "blockindex = 26 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel'" then
-        // {
-        //     values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
-        //     operations then IncrementSectionIndex(operations, index);
-        // };
+    };
+
+    // NGS Lung Panel
+    operations then InitSectionIndex(operations, index); // (re)set index to 0
+    operations.data as data then
+    {
+        data.values as values where "blockindex = 26 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel'" then
+        {
+            values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+            operations then IncrementSectionIndex(operations, index);
+        };
     };
 }
 
@@ -1617,7 +1619,6 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
-            //TODO:Please verify the value code to change to right  value
             values.value as value where "value = 'Amplifikation low-level'" then 
             {
                value -> tgt.component = create('BackboneElement') as component then
@@ -2765,7 +2766,7 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
     operations then MapFusionNGSStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> Sonstiges: Item required in Simplifier
-    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'Sonstiges');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'Sonstige Fusion NGS');
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -2810,8 +2811,8 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueCodeableConcept = cc('http://www.genenames.org',value);
-                value -> component.code                 = cc('http://loinc.org', '48018-6');
+                value -> component.valueString = value;
+                value -> component.code        = cc('http://loinc.org', '48018-6');
             };
         };
 
@@ -2821,7 +2822,7 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
                 value -> component.valueString = value;
-                value -> component.code        = cc('http://ncit.nci.nih.gov', 'C28510');
+                value -> component.code        = cc('http://loinc.org', '48018-6');
             };
         };
 
@@ -2840,8 +2841,8 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueInteger  = cast(value, 'FHIR.integer');
-                value -> component.code          = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'erster-fusionspartner-exon');
+                value -> component.valueString  = value;
+                value -> component.code         = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'erster-fusionspartner-exon');
             };
         };
         
@@ -2850,8 +2851,8 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
         {
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
-                value -> component.valueInteger  = cast(value, 'FHIR.integer');
-                value -> component.code          = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'zweiter-fusionspartner-exon');
+                value -> component.valueString  = value;
+                value -> component.code         = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'zweiter-fusionspartner-exon');
             };
         };
 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -51,11 +51,13 @@ group TransformSpecimenVorbefund(source operations: BackboneElement, target tgt:
     // Type : Item required on simplifier
     operations -> tgt.type as type, type.coding as snomedGlobalPatientSet, snomedGlobalPatientSet.system  = 'http://snomed.info/sct',
                                                                     snomedGlobalPatientSet.version = 'http://snomed.info/sct/900000000000207008',
-                                                                    snomedGlobalPatientSet.code    = 'UNKNOWN';
+                                                                    snomedGlobalPatientSet.code as code, code.extension as dataAbsentReason,
+                                                                    dataAbsentReason.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
+                                                                    dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
 
     // Subject 
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
-    
+
     // Access data
     operations.data as data then
     {
@@ -70,16 +72,6 @@ group TransformSpecimenVorbefund(source operations: BackboneElement, target tgt:
         data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_2471'" then
         {
             values.value as value -> tgt.receivedTime = dateOp(value, 'dateTime');
-        };
-
-        // Type: Item required on simplifier
-        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_2517'" then
-        {
-           values.value as value -> tgt.type as type, type.coding = create('Coding') as snomedGlobalPatientSet, snomedGlobalPatientSet.system = 'http://snomed.info/sct',
-                                                                                        snomedGlobalPatientSet.version = 'http://snomed.info/sct/900000000000207008',
-                                                                                        snomedGlobalPatientSet.code as code, code.extension as dataAbsentReason,
-                                                                                        dataAbsentReason.url = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
-                                                                                        dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
         };
     };
 }
@@ -1022,7 +1014,7 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
     operations then MapIHCStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code -> PD-L1: Item required in Simplifier
-    operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes', 'PD-L1');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'PD-L1');
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -3284,7 +3276,7 @@ group TransformObservationNGSPanelVorbefund(source operations: BackboneElement, 
     operations ->  tgt.status = cast('final', 'FHIR.code');
 
     // Code : Item required on simplifier : there is not code for NGS Lung Panel
-    operations -> tgt.code = cc('http://uk-koeln.de/fhir/ValueSet/nNGM/molpatho-obs-codes','NGS Panel');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes','NGS Panel');
 
     // Subject
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -24,7 +24,7 @@ group TransformBundleVorbefundFHIR(source operations: BackboneElement, target bu
         operations then CreateObservationHistologieVorbefund(operations, bundle, composition, section);
         operations then CreateObservationIHCVorbefund(operations, bundle, composition, section);
         operations then CreateObservationMPVorbefund(operations, bundle, composition, section);
-        // operations then CreateObservationFastTrackVorbefund(operations, bundle, composition, section);
+        operations then CreateObservationFastTrackVorbefund(operations, bundle, composition, section);
         // operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
         
         // there may be more than 1 instance of some Observation (Sonstiges and Lung Panel), thus an index is needed to reference (and create) the correct observation
@@ -2924,7 +2924,7 @@ group TransformObservationBRAFExon15Vorbefund(source operations: BackboneElement
     operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
-    operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C158854', 'BRAF Exon 15 Mutation');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'BRAF Exon 15', 'BRAF Exon 15');
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -2948,7 +2948,7 @@ group TransformObservationBRAFExon15Vorbefund(source operations: BackboneElement
         // Ergebnis
         data.values as values where "blockindex = 22 and groupindex = 0 and itemid = 'id_1946'" then
         {
-            values.value as value -> tgt.valueCodeableConcept = cc(' http://loinc.org', value);
+            values.value as ergebnis -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis);
         };
 
         //Change DNA -> dna-chg component
@@ -2985,7 +2985,7 @@ group TransformObservationEGFRExon19Vorbefund(source operations: BackboneElement
     operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
-    operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128662','EGFR Exon 19 Mutation');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'EGFR Exon 19', 'EGFR Exon 19');
 
     //Date of Assessment, Assay, Hersteller
     operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
@@ -2999,15 +2999,19 @@ group TransformObservationEGFRExon19Vorbefund(source operations: BackboneElement
         // ID + Composition insert
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr19'" then
         {
-            values.value as value -> tgt.id = value;
-            values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+            values.value as value where "unit.exists().not()" then // to not use the unit = 21 value element
+            {
+                values.value as value -> tgt.id = value;
+                values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+            };
         };
 
         // Ergebnis
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'id_1950'" then
         {
-            values.value as value -> tgt.valueCodeableConcept = cc(' http://loinc.org', value);
+            values.value as ergebnis -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis, ergebnis);
         };
+
         //Change DNA -> dna-chg component
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'id_1951'" then
         {
@@ -3041,7 +3045,7 @@ group TransformObservationEGFRExon20Vorbefund(source operations: BackboneElement
     operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
-    operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128663','EGFR Exon 20 Mutation');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'EGFR Exon 20', 'EGFR Exon 20');
 
     //Date of Assessment, Assay, Hersteller
     operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
@@ -3062,7 +3066,7 @@ group TransformObservationEGFRExon20Vorbefund(source operations: BackboneElement
         // Ergebnis
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'id_1954'" then
         {
-            values.value as value -> tgt.valueCodeableConcept = cc(' http://loinc.org', value);
+            values.value as ergebnis -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis, ergebnis);
         };
 
         //Change DNA -> dna-chg component
@@ -3099,7 +3103,7 @@ group TransformObservationEGFRExon21Vorbefund(source operations: BackboneElement
     operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
-    operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C128666','EGFR Exon 21 Mutation');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'EGFR Exon 21', 'EGFR Exon 21');
 
     //Date of Assessment, Assay, Hersteller
     operations then MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(operations, tgt);
@@ -3120,7 +3124,7 @@ group TransformObservationEGFRExon21Vorbefund(source operations: BackboneElement
         // Ergebnis
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'id_1958'" then
         {
-            values.value as value -> tgt.valueCodeableConcept = cc(' http://loinc.org', value);
+            values.value as ergebnis -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis, ergebnis);
         };
 
         //Change DNA -> dna-chg component
@@ -3157,7 +3161,7 @@ group TransformObservationKRASExon2Vorbefund(source operations: BackboneElement,
     operations then MapFastTrackStatusCategoryMethodVorbefund(operations, tgt);
 
     //Code: Item required on Simplifier
-    operations -> tgt.code = cc('http://ncit.nci.nih.gov', 'C135715','KRAS Exon 2 Mutation');
+    operations -> tgt.code = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/molpatho-obs-codes', 'KRAS Exon 2', 'KRAS Exon 2');
 
     // Patient reference
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -3181,8 +3185,9 @@ group TransformObservationKRASExon2Vorbefund(source operations: BackboneElement,
         // Ergebnis
         data.values as values where "blockindex = 24 and groupindex = 0 and itemid = 'id_1962'" then
         {
-            values.value as value -> tgt.valueCodeableConcept = cc(' http://loinc.org', value);
+            values.value as ergebnis -> tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis, ergebnis);
         };
+
         //Change DNA -> dna-chg component
         data.values as values where "blockindex = 24 and groupindex = 0 and itemid = 'id_1963'" then
         {
@@ -3667,6 +3672,7 @@ group MapObservationFastTrackDateAssayHerstellerEGFREXO1921Vorbefund(source oper
         {
             values.value as effectiveDT -> tgt.effectiveDateTime = dateOp(effectiveDT, 'date');
         };
+
         // Assay -> assay component
         data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'id_2608'" then
         {

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -3,7 +3,6 @@
 
 /*
     TODO 
-    - reference to Specimen is commented out until clarification 
     - Device: has no uuid and therefore cannot be referenced in BservationNGSPanel
 */
 
@@ -135,10 +134,10 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
 
         // Observations
         // Histologie
@@ -267,10 +266,10 @@ group TransformObservationHistologieVorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 
@@ -438,10 +437,10 @@ group TransformObservationBRAFIHCVorbefund(source operations: BackboneElement, t
         };
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 /* ---------------------- Observation CK7 IHC ------------------------ */
@@ -513,10 +512,10 @@ group TransformObservationCK7IHCVorbefund(source operations: BackboneElement, ta
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------------- Observation MIB1 IHC ------------------------ */
@@ -588,10 +587,10 @@ group TransformObservationMIB1IHCVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation NapsinA IHC ---------------------- */
@@ -663,10 +662,10 @@ group TransformObservationNapsinAIHCVorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------------- Observation P40 IHC ------------------------- */
@@ -738,10 +737,10 @@ group TransformObservationP40IHCVorbefund(source operations: BackboneElement, ta
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ----------------- Observation Synaptophysin IHC -------------------- */
@@ -813,10 +812,10 @@ group TransformObservationSynaptophysinIHCVorbefund(source operations: BackboneE
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation TTF1 IHC ------------------------- */
@@ -888,10 +887,10 @@ group TransformObservationTTF1IHCVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation ALK IHC --------------------------- */
@@ -926,10 +925,10 @@ group TransformObservationALKIHCVorbefund(source operations: BackboneElement, ta
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation MET IHC --------------------------- */
@@ -994,10 +993,10 @@ group TransformObservationMETIHCVorbefund(source operations: BackboneElement, ta
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation PD-L1 IHC ------------------------- */
@@ -1089,10 +1088,10 @@ group TransformObservationPDL1IHCVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation ROS1 IHC -------------------------- */
@@ -1127,10 +1126,10 @@ group TransformObservationROS1IHCVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 
@@ -1252,10 +1251,10 @@ group TransformObservationALKCISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation MET CISH -------------------------- */
@@ -1333,10 +1332,10 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation RET CISH -------------------------- */
@@ -1394,10 +1393,10 @@ group TransformObservationRETCISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation ROS1 CISH ------------------------- */
@@ -1465,10 +1464,10 @@ group TransformObservationROS1CISHVorbefund(source operations: BackboneElement, 
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation ALK FISH -------------------------- */
@@ -1535,10 +1534,10 @@ group TransformObservationALKFISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation MET FISH -------------------------- */
@@ -1730,10 +1729,10 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation RET FISH -------------------------- */
@@ -1802,10 +1801,10 @@ group TransformObservationRETFISHVorbefund(source operations: BackboneElement, t
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* --------------------- Observation ROS1 FISH ------------------------- */
@@ -1873,10 +1872,10 @@ group TransformObservationROS1FISHVorbefund(source operations: BackboneElement, 
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 
@@ -2051,10 +2050,10 @@ group TransformObservationALKFusionNGSVorbefund(source operations: BackboneEleme
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ------------------ Observation RET FusionNGS ------------------------ */
@@ -2142,10 +2141,10 @@ group TransformObservationRETFusionNGSVorbefund(source operations: BackboneEleme
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------- Observation ROS1 FusionNGS ------------------------- */
@@ -2233,10 +2232,10 @@ group TransformObservationROS1FusionNGSVorbefund(source operations: BackboneElem
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 } 
 /* ----------------- Observation NTRK1 FusionNGS ----------------------- */
@@ -2317,10 +2316,10 @@ group TransformObservationNTRK1FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------- Observation NTRK2 FusionNGS ------------------------ */
@@ -2401,10 +2400,10 @@ group TransformObservationNTRK2FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ----------------- Observation NTRK3 FusionNGS ----------------------- */
@@ -2485,10 +2484,10 @@ group TransformObservationNTRK3FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------- Observation FGFR1 FusionNGS ------------------------ */
@@ -2569,10 +2568,10 @@ group TransformObservationFGFR1FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ----------------- Observation FGFR2 FusionNGS ----------------------- */
@@ -2654,10 +2653,10 @@ group TransformObservationFGFR2FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ----------------- Observation FGFR3 FusionNGS ----------------------- */
@@ -2738,10 +2737,10 @@ group TransformObservationFGFR3FusionNGSVorbefund(source operations: BackboneEle
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
     };
 }
 /* ---------------- Observation Sonstiges FusionNGS -------------------- */
@@ -2842,10 +2841,10 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };    
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };    
     };
 }
 
@@ -2945,10 +2944,10 @@ group TransformObservationBRAFExon15Vorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 /* ------------ Observation EGFR Exon 19 Fast Track -------------------- */
@@ -3005,10 +3004,10 @@ group TransformObservationEGFRExon19Vorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 /* ------------ Observation EGFR Exon 20 Fast Track -------------------- */
@@ -3063,10 +3062,10 @@ group TransformObservationEGFRExon20Vorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 /* ------------ Observation EGFR Exon 21 Fast Track -------------------- */
@@ -3121,10 +3120,10 @@ group TransformObservationEGFRExon21Vorbefund(source operations: BackboneElement
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 /* -------------- Observation KRAS Exon Fast Track --------------------- */
@@ -3182,10 +3181,10 @@ group TransformObservationKRASExon2Vorbefund(source operations: BackboneElement,
 
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // }; 
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        }; 
     };
 }
 
@@ -3383,10 +3382,10 @@ group TransformObservationNGSPanelVorbefund(source operations: BackboneElement, 
     
         // Referenzen
         // Specimen
-        // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
-        // {
-        //     values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
-        // };
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
+        {
+            values.value as value -> tgt.specimen = create('Reference') as specimen, specimen.reference = evaluate(value, '\'Specimen/\' + $this');
+        };
 
         // Device
         // data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'uuid_device'" then

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -2795,7 +2795,8 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
                 value -> component.valueString = value;
-                value -> component.code        = cc('http://loinc.org', '48018-6');
+                value -> component.code        = cc('http://loinc.org', '48018-6')  as codeableConcept,
+                                                    codeableConcept.coding = c('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'erster-fusionspartner');
             };
         };
 
@@ -2805,7 +2806,8 @@ group TransformObservationSonstigesFusionNGSVorbefund(source operations: Backbon
             values.value as value -> tgt.component = create('BackboneElement') as component then
             {
                 value -> component.valueString = value;
-                value -> component.code        = cc('http://loinc.org', '48018-6');
+                value -> component.code        = cc('http://loinc.org', '48018-6')  as codeableConcept,
+                                                codeableConcept.coding = c('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'zweiter-fusionspartner');
             };
         };
 

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -28,7 +28,7 @@ group TransformBundleVorbefundFHIR(source operations: BackboneElement, target bu
         // operations then CreateDeviceNGSPanelVorbefund(operations, bundle, composition, section);
         
         // there may be more than 1 instance of some Observation (Sonstiges and Lung Panel), thus an index is needed to reference (and create) the correct observation
-        // operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
+        operations then CreateDiagnosticReportVorbefund(operations, bundle, composition, section, index);
         // operations then CreateObservationFusionNGSVorbefund(operations, bundle, composition, section, index);  
         // operations then CreateObservationNGSPanelVorbefund(operations, bundle, composition, section, index);  
     };
@@ -115,12 +115,14 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
                     status.extension as dataAbsentReason, 
                     dataAbsentReason.url       = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
                     dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
+    // operations -> tgt.status = 'final';
 
     // code: Item required on simplifier
     operations ->  tgt.code as code, 
                     code.extension as dataAbsentReason, 
                     dataAbsentReason.url       = 'http://hl7.org/fhir/StructureDefinition/data-absent-reason', 
                     dataAbsentReason.valueCode = cast('not-asked', 'FHIR.code');
+    // operations -> tgt.code = cc('http://loinc.org', '50398-7'); 
 
     // Subject 
     operations -> tgt.subject = create('Reference') as subject, subject.reference = evaluate(composition, '\'Patient/\' + $this.subject.reference');
@@ -135,14 +137,6 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
             values.value as value -> section.entry = create('Reference') as diagnosticReport, diagnosticReport.reference = evaluate(value, '\'DiagnosticReport/\' + $this');
         };
 
-        /* ------------------------- EXTERNES TUMORMATERIAL ----------------------------- */
-        // Befunddatum
-        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_1653'" then
-        {
-            values.value as value -> tgt.issued =  dateOp(value, 'date');
-        };
-
-        // Referenzen
         // Befundnummer 
         data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_1654'" then
         {
@@ -151,6 +145,14 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
                                                           befundNummer.value  = id;
         };
 
+        /* ------------------------- EXTERNES TUMORMATERIAL ----------------------------- */
+        // Befunddatum
+        data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'id_1653'" then
+        {
+            values.value as value -> tgt.issued =  dateOp(value, 'date');
+        };
+
+        // Referenzen
         // Specimen
         // data.values as values where "blockindex = 0 and groupindex = 0 and itemid = 'uuid_specimen_nngm3'" then
         // {
@@ -171,56 +173,41 @@ group TransformDiagnosticReportVorbefund(source operations: BackboneElement, tar
         // MP: CISH and FISH
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2509'" then
         {
-            let cish = 'CISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMPVorbefund(operations, cish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationCISHMPVorbefund(operations, value, reference);
         };
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2510'" then
         {
-            let fish = 'FISH';
-            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationMPVorbefund(operations, fish, value, reference);
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFISHMPVorbefund(operations, value, reference);
         };
-        // FusionNGS
-        data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2511'" then
-        {
-            // if Sonstiges: create n observation references (with n according to repeatindex)
-            values.value where "$this.value = 'Sonstiges'" then
-            {
-                operations.data as data, data.values as values where "blockindex = 21 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsFusionExpression_sonstiges'" then
-                {
-                    values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
-                    operations then IncrementSectionIndex(operations, index);
-                };
-            };
-            values.value where "$this.value != 'Sonstiges'" then
-            {   
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusionVorbefund(operations, value, reference);
-            };
-        };
+        // // FusionNGS
+        // data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2511'" then
+        // {
+        //     // if Sonstiges: create n observation references (with n according to repeatindex)
+        //     values.value where "$this.value = 'Sonstiges'" then
+        //     {
+        //         operations.data as data, data.values as values where "blockindex = 21 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsFusionExpression_sonstiges'" then
+        //         {
+        //             values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+        //             operations then IncrementSectionIndex(operations, index);
+        //         };
+        //     };
+        //     values.value where "$this.value != 'Sonstiges'" then
+        //     {   
+        //         values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationNGSFusionVorbefund(operations, value, reference);
+        //     };
+        // };
         // FastTrack
         data.values as values where "blockindex = 2 and groupindex = 0 and itemid = 'id_2512'" then
         {
-            // if EGFR Exon 19-21: create 3 observation references
-            values.value where "$this.value = 'EGFR Exon 19-21'" then
-            {
-                let EGFFR19 = 'EGFR Exon 19';
-                let EGFFR20 = 'EGFR Exon 20';
-                let EGFFR21 = 'EGFR Exon 21';
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR19, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR20, reference);
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, EGFFR21, reference);
-            };
-            values.value where "$this.value != 'EGFR Exon 19-21'" then
-            {
-                values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, value, reference);
-            };
+            values.value as value -> tgt.result = create('Reference') as reference then SetReferenceToObservationFastTrackVorbefund(operations, value, tgt);
         };
-        // NGS Lung Panel
-        operations then InitSectionIndex(operations, index); // (re)set index to 0
-        data.values as values where "blockindex = 26 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel'" then
-        {
-            values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
-            operations then IncrementSectionIndex(operations, index);
-        };
+        // // NGS Lung Panel
+        // operations then InitSectionIndex(operations, index); // (re)set index to 0
+        // data.values as values where "blockindex = 26 and groupindex = 0 and repeatindex = %index.sectionIndex and itemid = 'uuid_ngsPanel'" then
+        // {
+        //     values.value as value -> tgt.result = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
+        //     operations then IncrementSectionIndex(operations, index);
+        // };
     };
 }
 
@@ -3785,71 +3772,67 @@ group SetReferenceToObservationIHCVorbefund(source operations: BackboneElement, 
         };     
     };
 }
-group SetReferenceToObservationMPVorbefund(source operations: BackboneElement, source cishFish: string, source name: string, target tgt: Reference)
+group SetReferenceToObservationCISHMPVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
 {
     // Check which CISH observation should be referenced
-    cishFish where "%cishFish = 'CISH'" then 
+    name where "%name = 'ALK'" then 
     {
-        name where "%name = 'ALK'" then 
+        operations.data as data, data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'uuid_ish_alk'" then
         {
-            operations.data as data, data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'uuid_ish_alk'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
         };
-        name where "%name = 'MET'" then 
-        {
-            operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'uuid_ish_met'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
-        }; 
-        name where "%name = 'RET'" then 
-        {
-            operations.data as data, data.values as values where "blockindex = 20 and groupindex = 0 and itemid = 'uuid_ish_ret'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
-        }; 
-        name where "%name = 'ROS1'" then 
-        {
-            operations.data as data, data.values as values where "blockindex = 17 and groupindex = 0 and itemid = 'uuid_ish_ros1'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
-        }; 
     };
-
-    // Check which FISH observation should be referenced
-    cishFish where "%cishFish = 'FISH'" then 
+    name where "%name = 'MET'" then 
     {
-        name where "%name = 'ALK'" then 
+        operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'uuid_ish_met'" then
         {
-            operations.data as data, data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'uuid_fish_alk'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
         };
-        name where "%name = 'MET'" then 
+    }; 
+    name where "%name = 'RET'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 20 and groupindex = 0 and itemid = 'uuid_ish_ret'" then
         {
-            operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'uuid_fish_met'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
-        }; 
-        name where "%name = 'RET'" then 
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+    }; 
+    name where "%name = 'ROS1'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 17 and groupindex = 0 and itemid = 'uuid_ish_ros1'" then
         {
-            operations.data as data, data.values as values where "blockindex = 20 and groupindex = 0 and itemid = 'uuid_fish_ret'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
-        }; 
-        name where "%name = 'ROS1'" then 
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+    }; 
+}
+group SetReferenceToObservationFISHMPVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
+{
+    // Check which FISH observation should be referenced
+    name where "%name = 'ALK'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 3 and groupindex = 0 and itemid = 'uuid_fish_alk'" then
         {
-            operations.data as data, data.values as values where "blockindex = 17 and groupindex = 0 and itemid = 'uuid_fish_ros1'" then
-            {
-                values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-            };
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+    };
+    name where "%name = 'MET'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'uuid_fish_met'" then
+        {
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+    }; 
+    name where "%name = 'RET'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 20 and groupindex = 0 and itemid = 'uuid_fish_ret'" then
+        {
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+    }; 
+    name where "%name = 'ROS1'" then 
+    {
+        operations.data as data, data.values as values where "blockindex = 17 and groupindex = 0 and itemid = 'uuid_fish_ros1'" then
+        {
+            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
         };
     };
 }
@@ -3920,42 +3903,46 @@ group SetReferenceToObservationNGSFusionVorbefund(source operations: BackboneEle
         };
     };
 }
-group SetReferenceToObservationFastTrackVorbefund(source operations: BackboneElement, source name: string, target tgt: Reference)
+group SetReferenceToObservationFastTrackVorbefund(source operations: BackboneElement, source name: string, target tgt: DiagnosticReport)
 {
     // Check which observation should be referenced
     name where "%name = 'BRAF Exon 15'" then 
     {
-        operations.data as data, data.values as values where "blockindex = 22 and groupindex = 0 and itemid = 'uuid_fasttrack_braf15'" then
+        operations.data as data, data.values as values where "blockindex = 22 and groupindex = 0 and itemid = 'uuid_fasttrack_braf15'" 
+            -> tgt.result = create('Reference') as reference then
         {
-            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+            values.value as value -> reference.reference = evaluate(value, '\'Observation/\' + $this');
         };
     };
-    name where "%name = 'EGFR Exon 19'" then 
+    name where "%name = 'EGFR Exon 19-21'" then
     {
-        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr19'" then
+        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr19'" then            
         {
-            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+            values.value as value where "unit.exists().not()" -> tgt.result = create('Reference') as reference then // to not use the unit = 21 value element
+            {
+                values.value as value -> reference.reference = evaluate(value, '\'Observation/\' + $this');
+            };
+        };
+
+        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr20'"
+            -> tgt.result = create('Reference') as reference then
+        {
+            values.value as value -> reference.reference = evaluate(value, '\'Observation/\' + $this');
+        };
+
+        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr21'"  
+            -> tgt.result = create('Reference') as reference then
+        {
+            values.value as value -> reference.reference = evaluate(value, '\'Observation/\' + $this');
         };
     };
-    name where "%name = 'EGFR Exon 20'" then 
-    {
-        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr20'" then
-        {
-            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-        };
-    };
-    name where "%name = 'EGFR Exon 21'" then 
-    {
-        operations.data as data, data.values as values where "blockindex = 23 and groupindex = 0 and itemid = 'uuid_fasttrack_egfr21'" then
-        {
-            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
-        };
-    };
+
     name where "%name = 'KRAS Exon 2'" then 
     {
-        operations.data as data, data.values as values where "blockindex = 24 and groupindex = 0 and itemid = 'uuid_fasttrack_kras2'" then
+        operations.data as data, data.values as values where "blockindex = 24 and groupindex = 0 and itemid = 'uuid_fasttrack_kras2'"  
+            -> tgt.result = create('Reference') as reference then
         {
-            values.value as value -> tgt.reference = evaluate(value, '\'Observation/\' + $this');
+            values.value as value -> reference.reference = evaluate(value, '\'Observation/\' + $this');
         };
     };
 }

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -1309,27 +1309,23 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
             values.value as value -> section.entry = create('Reference') as observation, observation.reference = evaluate(value, '\'Observation/\' + $this');
         };
 
-        //Ergebnis 
+        //Ergebnis
         data.values as values where "blockindex = 6 and groupindex = 0 and itemid = 'id_2147'" then
         {
-            values.value as value where "value = 'positiv (high-level amplification)'" then 
+            values.value where "$this.value = 'positiv (high-level amplification)'
+                               or $this.value = 'positiv (moderate-level amplification)'" then 
             {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6576-8', 'Positive');
+                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://uk-koeln.de/fhir/CodeSystem/nNGM/ergebnis', ergebnis, ergebnis);
             };
 
-            values.value as value where "value = 'positiv (moderate-level amplification)'" then 
+            values.value where "$this.value = 'negativ'" then 
             {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
+                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
             };
 
-            values.value as value where "value = 'negativ'" then 
+            values.value where "$this.value = 'nicht auswertbar'" then 
             {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA6577-6', 'Negative');
-            };
-
-            values.value as value where "value = 'nicht auswertbar'" then 
-            {
-                value ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
+                values.value as ergebnis ->  tgt.valueCodeableConcept = cc('http://loinc.org', 'LA18198-4', 'No call');
             };
         };
         
@@ -1340,7 +1336,7 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA6576-8', 'Positive');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA9193-9', 'High');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1348,7 +1344,7 @@ group TransformObservationMETCISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA8982-6', 'Medium');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1622,7 +1618,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA6576-8', 'Positive');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA9193-9', 'High');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1630,7 +1626,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA8982-6', 'Medium');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1639,7 +1635,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA32-8', 'No');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA9194-7', 'Low');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1647,7 +1643,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
             {
                 value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA6577-6', 'Negative');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA32-8', 'No');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };
@@ -1655,7 +1651,7 @@ group TransformObservationMETFISHVorbefund(source operations: BackboneElement, t
             {
                value -> tgt.component = create('BackboneElement') as component then
                 {
-                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA18198-4', 'No call');
+                    value -> component.valueCodeableConcept    = cc('http://loinc.org', 'LA11884-6', 'Indeterminate');
                     value -> component.code                    = cc('http://uk-koeln.de/fhir/CodeSystem/tbd-codes', 'amplification-level');
                 };
             };

--- a/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
+++ b/CDS Maps/Individual Maps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Vorbefund.map
@@ -217,7 +217,7 @@ group CreateObservationHistologieVorbefund(source operations: BackboneElement, t
 /* ---------------------- ObservationHistologie ----------------------- */
 group TransformObservationHistologieVorbefund(source operations: BackboneElement, target tgt: Observation, target composition: Composition, target section: BackboneElement)
 {
-    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie';
+    operations -> tgt.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie';
     
     // Status 
     operations ->  tgt.status = cast('final', 'FHIR.code');

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Histologie.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Histologie.map
@@ -14,7 +14,7 @@ group TransformHistologieCDS(source entry: BackboneElement, target tgt: Backbone
     entry.resource as diagnosticReport where "resource is DiagnosticReport and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund'" 
         then TransformHLDiagnosticReportCDS(diagnosticReport, tgt);
 
-    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie'" 
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie'" 
         then TransformHLObservationCDS(observation, tgt);
 }
 

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-NGS Fusion.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-NGS Fusion.map
@@ -66,9 +66,9 @@ group TransformFSObservationCDS(source observation: Observation, target tgt: Bac
     observation where "code.coding.code = 'NTRK1'" then TransformFSObservationNTRK1CDS(observation, tgt);
     observation where "code.coding.code = 'NTRK2'" then TransformFSObservationNTRK2CDS(observation, tgt);
     observation where "code.coding.code = 'NTRK3'" then TransformFSObservationNTRK3CDS(observation, tgt);
-    observation where "code.coding.code = 'FGFR1'" then TransformFSObservationFHFR1CDS(observation, tgt);
-    observation where "code.coding.code = 'FGFR2'" then TransformFSObservationFHFR2CDS(observation, tgt);
-    observation where "code.coding.code = 'FGFR3'" then TransformFSObservationFHFR3CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR1'" then TransformFSObservationFGFR1CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR2'" then TransformFSObservationFGFR2CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR3'" then TransformFSObservationFGFR3CDS(observation, tgt);
     observation where "code.coding.code = 'Sonstige Fusion NGS'" then TransformFSObservationSonstigeCDS(observation, tgt, index);
 }
 
@@ -689,7 +689,7 @@ group TransformFSObservationNTRK3CDS(source observation: Observation, target tgt
 }
 
 /*---------------------- Observation FGFR1 ----------------------- */
-group TransformFSObservationFHFR1CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformFSObservationFGFR1CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 11, 0, id_2576
     observation->tgt.data as data then
@@ -774,7 +774,7 @@ group TransformFSObservationFHFR1CDS(source observation: Observation, target tgt
 }
 
 /*---------------------- Observation FGFR2 ----------------------- */
-group TransformFSObservationFHFR2CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformFSObservationFGFR2CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 12, 0, id_2568
     observation->tgt.data as data then
@@ -839,7 +839,7 @@ group TransformFSObservationFHFR2CDS(source observation: Observation, target tgt
         };
     };
 
-    //5' Fusionspartner Exon -> 12, 0, id_2575
+    //3' Fusionspartner Exon -> 12, 0, id_2575
     observation->tgt.data as data then
     {
         observation.component as component then
@@ -859,7 +859,7 @@ group TransformFSObservationFHFR2CDS(source observation: Observation, target tgt
 }
 
 /*---------------------- Observation FGFR3 ----------------------- */
-group TransformFSObservationFHFR3CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformFSObservationFGFR3CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 13, 0, id_2560
     observation->tgt.data as data then
@@ -924,7 +924,7 @@ group TransformFSObservationFHFR3CDS(source observation: Observation, target tgt
         };
     };
 
-    //5' Fusionspartner Exon -> 13, 0, id_2567
+    //3' Fusionspartner Exon -> 13, 0, id_2567
     observation->tgt.data as data then
     {
         observation.component as component then

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-NGS Fusion.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-NGS Fusion.map
@@ -976,24 +976,26 @@ group TransformFSObservationSonstigeCDS(source observation: Observation, target 
         };
     };
 
-    // Erster Fusionspartner -> 14, 0, 0 , id_2255 if 1 (or more) components with this code
-    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 1" -> tgt.data as data then
+    // Erster/Zweiter Fusionspartner -> 14, 0, 0 , id_2255/id_2556
+    observation.component as component where "component.where(code.coding.where(code = '48018-6'))" then
     {
-        observation->data.blockindex = 14;
-        observation->data.groupindex = 0;
-        observation->data.repeatindex = evaluate(index, '$this.sectionIndex');
-        observation->data.itemid = 'id_2255';
-        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[0].valueString');
-    };
+        component as ersterFusionspartner where "code.coding.where(code = 'erster-fusionspartner') and valueString.exists()" -> tgt.data as data then
+        {
+            observation->data.blockindex = 14;
+            observation->data.groupindex = 0;
+            observation->data.repeatindex = evaluate(index, '$this.sectionIndex');
+            observation->data.itemid = 'id_2255';
+            ersterFusionspartner.valueString as valueString ->data.values as values, values.value = valueString;
+        };
 
-    // Zweiter Fusionspartner -> 14, 0, 0 , id_2256 if 2 (or more) components with this code
-    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 2" -> tgt.data as data then
-    {
-        observation->data.blockindex = 14;
-        observation->data.groupindex = 0;
-        observation->data.repeatindex = evaluate(index, '$this.sectionIndex');
-        observation->data.itemid = 'id_2256';
-        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[1].valueString');
+        component as zweiterFusionspartner where "code.coding.where(code = 'zweiter-fusionspartner') and valueString.exists()" -> tgt.data as data then
+        {
+            observation->data.blockindex = 14;
+            observation->data.groupindex = 0;
+            observation->data.repeatindex = evaluate(index, '$this.sectionIndex');
+            observation->data.itemid = 'id_2256';
+            zweiterFusionspartner.valueString as valueString ->data.values as values, values.value = valueString;
+        };
     };
 
     //Anzahl der Fusionsreads -> 14, 0, 0 , id_2257

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -1,13 +1,6 @@
 /// version = 0.1
 /// title = "nNGM_Mapping_VorbefundCTS"
 
-/* TO DO
-    [EXTERNES TUMORMATERIAL] Section form 
-    - Eingang des Tumormaterials am nNGM-Standort item form doesn't exist in Sea Table. Missing implementation to map in this script.
-
-    - Some IHC Observations seem to have an issue (connected to Fix #70), please check TODOs in there
-*/
-
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundCDS" = nNGM_Mapping_VorbefundCDS
 
 uses "http://hl7.org/fhir/StructureDefinition/Bundle" as source
@@ -51,12 +44,12 @@ group TransformVBDiagnosticReportCDS(source diagnosticReport: DiagnosticReport, 
     //Befunddatum -> 0, 0, id_1653
     diagnosticReport -> tgt.data as data then
     {
-        diagnosticReport.issued as issued then
+        diagnosticReport.effectiveDateTime as edt then
         {   
             diagnosticReport -> data.blockindex  = 0;
             diagnosticReport -> data.groupindex  = 0;
             diagnosticReport -> data.itemid      = 'id_1653';
-            issued -> data.values as values, values.value = issued;
+            edt -> data.values as values, values.value = edt;
         };
     };                
     //Befundnummer -> 0, 0, id_1654

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -164,6 +164,7 @@ group TransformVBIHCObservationBRAFCDS(source observation: Observation, target t
         observation -> data.itemid     = 'braf_ihc_group';
         dateOfAssessment -> data.values as values, values.value = dateOfAssessment;
     };
+
     //Phänotyp: phanotyp component-> 4, 0, braf_ihc_phaenotype
     observation -> tgt.data as data then
     {
@@ -192,6 +193,22 @@ group TransformVBIHCObservationBRAFCDS(source observation: Observation, target t
             observation->data.groupindex = 0;
             observation->data.itemid = 'braf_ihc_result';
             code->data.values as values, values.value = code;
+        };
+    };
+
+    // Antikörper
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16295'" then
+        {
+            component.valueCodeableConcept as vcc, vcc.coding as coding,
+                coding.code as code then
+            {
+                observation -> data.blockindex = 4;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'braf_ihc_ab';
+                observation -> data.values as values, values.value = code;
+            };
         };
     };
 }

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -23,17 +23,19 @@ group TransformVorbefundCDS(source entry: BackboneElement, target tgt: BackboneE
         then TransformVBObservationIHCCDS(observationIHC, tgt);
 
     // Molekularpathologie
-    // entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'"
-    //     then TransformVBCISHObservationCDS(observation, tgt);
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'"
+        then TransformVBCISHObservationMPCDS(observation, tgt);
 
-    // entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'"
-    //     then TransformVBFISHObservationCDS(observation, tgt);
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'"
+        then TransformVBFISHObservationMPCDS(observation, tgt);
 
-    // Fusion NGS 
+    // Fusion NGS - evaluates index.caseIndex as repeatindex
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'"
+        then TransformVBObservationFSCDS(observation, tgt, index);
 
     // Fast Track 
 
-    // NGS Lung Panel  
+    // NGS Lung Panel - evaluates index.sectionIndex as repeatindex
 }
 
 /* ------------------------------ Specimen ---------------------------- */
@@ -130,21 +132,21 @@ group TransformVBObservationHistologieCDS(source observation: Observation, targe
 ----------------------------------------------------------------------- */
 group TransformVBObservationIHCCDS(source observation: Observation, target tgt: BackboneElement)
 {
-    observation where "code.coding.code = 'BRAF'" then TransformVBObservationBRAFCDS(observation, tgt);
-    observation where "code.coding.code = 'CK7'" then TransformVBObservationCK7CDS(observation, tgt);
-    observation where "code.coding.code = 'MIB1'" then TransformVBObservationMIB1CDS(observation, tgt);
-    observation where "code.coding.code = 'Napsin A'" then TransformVBObservationNapsinACDS(observation, tgt);
-    observation where "code.coding.code = 'P40'" then TransformVBObservationP40CDS(observation, tgt);
-    observation where "code.coding.code = 'Synaptophysin'" then TransformVBObservationSynaptophysinCDS(observation, tgt);
-    observation where "code.coding.code = 'TTF1'" then TransformVBObservationTTF1CDS(observation, tgt);
-    observation where "code.coding.code = 'ALK'" then TransformVBObservationALKCDS(observation, tgt);
-    observation where "code.coding.code = 'MET'" then TransformVBObservationMETCDS(observation, tgt);
-    observation where "code.coding.code = 'PD-L1'" then TransformVBObservationPDL1CDS(observation, tgt);
-    observation where "code.coding.code = 'ROS1'" then TransformVBObservationROS1CDS(observation, tgt);
+    observation where "code.coding.code = 'BRAF'" then TransformVBIHCObservationBRAFCDS(observation, tgt);
+    observation where "code.coding.code = 'CK7'" then TransformVBIHCObservationCK7CDS(observation, tgt);
+    observation where "code.coding.code = 'MIB1'" then TransformVBIHCObservationMIB1CDS(observation, tgt);
+    observation where "code.coding.code = 'Napsin A'" then TransformVBIHCObservationNapsinACDS(observation, tgt);
+    observation where "code.coding.code = 'P40'" then TransformVBIHCObservationP40CDS(observation, tgt);
+    observation where "code.coding.code = 'Synaptophysin'" then TransformVBIHCObservationSynaptophysinCDS(observation, tgt);
+    observation where "code.coding.code = 'TTF1'" then TransformVBIHCObservationTTF1CDS(observation, tgt);
+    observation where "code.coding.code = 'ALK'" then TransformVBIHCObservationALKCDS(observation, tgt);
+    observation where "code.coding.code = 'MET'" then TransformVBIHCObservationMETCDS(observation, tgt);
+    observation where "code.coding.code = 'PD-L1'" then TransformVBIHCObservationPDL1CDS(observation, tgt);
+    observation where "code.coding.code = 'ROS1'" then TransformVBIHCObservationROS1CDS(observation, tgt);
 }
 
 /* ---------------------- Observation BRAF IHC ------------------------ */
-group TransformVBObservationBRAFCDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationBRAFCDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 4, 0, braf_ihc_group
     observation.effectiveDateTime as dateOfAssessment -> tgt.data as data then
@@ -187,7 +189,7 @@ group TransformVBObservationBRAFCDS(source observation: Observation, target tgt:
 }
 
 /* ---------------------- Observation CK7 IHC ------------------------ */
-group TransformVBObservationCK7CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationCK7CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 5, 0, id_2037
     observation-> tgt.data as data then
@@ -234,7 +236,7 @@ group TransformVBObservationCK7CDS(source observation: Observation, target tgt: 
 }
 
 /* --------------------- Observation MIB1 IHC ------------------------ */
-group TransformVBObservationMIB1CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationMIB1CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 7, 0, id_2055
     observation-> tgt.data as data then
@@ -281,7 +283,7 @@ group TransformVBObservationMIB1CDS(source observation: Observation, target tgt:
 }
 
 /* ------------------ Observation Napsin A IHC ----------------------- */
-group TransformVBObservationNapsinACDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationNapsinACDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 14, 0, id_2064
     observation-> tgt.data as data then
@@ -328,7 +330,7 @@ group TransformVBObservationNapsinACDS(source observation: Observation, target t
 }
 
 /* ---------------------- Observation P40 IHC ------------------------ */
-group TransformVBObservationP40CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationP40CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 15, 0, id_2073
     observation-> tgt.data as data then
@@ -375,7 +377,7 @@ group TransformVBObservationP40CDS(source observation: Observation, target tgt: 
 }
 
 /* ----------------- Observation Synaptophysin IHC -------------------- */
-group TransformVBObservationSynaptophysinCDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationSynaptophysinCDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 18, 0, id_2080
     observation-> tgt.data as data then
@@ -422,7 +424,7 @@ group TransformVBObservationSynaptophysinCDS(source observation: Observation, ta
 }
 
 /* --------------------- Observation TTF1 IHC ------------------------- */
-group TransformVBObservationTTF1CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationTTF1CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 19, 0, id_2089
     observation-> tgt.data as data then
@@ -468,7 +470,7 @@ group TransformVBObservationTTF1CDS(source observation: Observation, target tgt:
 }
 
 /* --------------------- Observation ALK IHC -------------------------- */
-group TransformVBObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 3, 0,id_2098
     //Phaenotyp -> 3, 0, id_2099 
@@ -491,7 +493,7 @@ group TransformVBObservationALKCDS(source observation: Observation, target tgt: 
 }
 
 /* --------------------- Observation MET IHC -------------------------- */
-group TransformVBObservationMETCDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationMETCDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 6, 0,id_2132
     //Phaenotyp -> 6, 0, id_2133
@@ -546,7 +548,7 @@ group TransformVBObservationMETCDS(source observation: Observation, target tgt: 
 }
 
 /* --------------------- Observation PD-L1 IHC ------------------------- */
-group TransformVBObservationPDL1CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationPDL1CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 16, 0, id_2172
     observation-> tgt.data as data then
@@ -626,7 +628,7 @@ group TransformVBObservationPDL1CDS(source observation: Observation, target tgt:
 }
 
 /* --------------------- Observation ROS1 IHC -------------------------- */
-group TransformVBObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
+group TransformVBIHCObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
 {
     //Date of Assessment -> 17, 0,id_2211
     //Phaenotyp -> 17, 0, id_2212
@@ -649,1898 +651,1373 @@ group TransformVBObservationROS1CDS(source observation: Observation, target tgt:
 }
 
 
+/*---------------------------------------------------------------------
+                        Molekularpathologie (MP)                
+------------------------------------------------------------------------ */
+/* --------------- CISH Observation ---------------------- */
+group TransformVBCISHObservationMPCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    observation where "code.coding.code = 'ALK'" then TransformVBCISHObservationALKCDS(observation, tgt);
+    observation where "code.coding.code = 'MET'" then TransformVBCISHObservationMETCDS(observation, tgt);
+    observation where "code.coding.code = 'RET'" then TransformVBCISHObservationRETCDS(observation, tgt);
+    observation where "code.coding.code = 'ROS1'" then TransformVBCISHObservationROS1CDS(observation, tgt);
+}
 
+/* --------------- FISH Observation ---------------------- */
+group TransformVBFISHObservationMPCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    observation where "code.coding.code = 'ALK'" then TransformVBFISHObservationALKCDS(observation, tgt);
+    observation where "code.coding.code = 'MET'" then TransformVBFISHObservationMETCDS(observation, tgt);
+    observation where "code.coding.code = 'RET'" then TransformVBFISHObservationRETCDS(observation, tgt);
+    observation where "code.coding.code = 'ROS1'" then TransformVBFISHObservationROS1CDS(observation, tgt);
+}
 
+/* --------------------- Observation ALK CISH -------------------------- */
+group TransformVBCISHObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 3, 0,id_2098
+    //Phaenotyp -> 3, 0, id_2099
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
 
+    //Ergebnis -> 3, 0, id_2112
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 3;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2112';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 3, 0, id_2113
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                observation->data.blockindex = 3;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2113';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
 
+/* --------------------- Observation MET CISH -------------------------- */
+group TransformVBCISHObservationMETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 6, 0,id_2132
+    //Phaenotyp -> 6, 0, id_2133
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 6, 0, id_2147
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 6;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2147';
+            coding.code as code where "code = 'positiv (high-level amplification)'" -> data.values as values, values.value = code;
+            coding.code as code where "code = 'positiv (moderate-level amplification)'" -> data.values as values, values.value = code;
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+
+    //Amplifikation -> amplification-level component -> 6, 0, id_2148
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.code where "code.coding.code = 'amplification-level'" then
+            {
+                component.valueCodeableConcept as valueCodeableConcept,
+                valueCodeableConcept.coding as coding, 
+                coding.code as code where "code ='LA9193-9'" then 
+                {
+                    observation -> data.blockindex = 6;
+                    observation -> data.groupindex = 0;
+                    observation -> data.itemid     = 'id_2148';
+                    code.value as value -> data.values as values, values.value = 'Amplifikation high-level';
+                };
+                component.valueCodeableConcept as valueCodeableConcept,
+                valueCodeableConcept.coding as coding, 
+                coding.code as code where "code ='LA8982-6'" then 
+                {
+                    observation -> data.blockindex = 6;
+                    observation -> data.groupindex = 0;
+                    observation -> data.itemid     = 'id_2148';
+                    code.value as value ->data.values as values, values.value = 'Amplifikation moderate-level';
+                };
+                component.valueCodeableConcept as valueCodeableConcept,
+                valueCodeableConcept.coding as coding, 
+                coding.code as code where "code ='LA32-8'" then 
+                {
+                    observation -> data.blockindex = 6;
+                    observation -> data.groupindex = 0;
+                    observation -> data.itemid     = 'id_2148';
+                    code.value as value ->data.values as values, values.value = 'keine Amplifikation';
+                };
+            };
+        };
+    };
+}
+
+/* --------------------- Observation RET CISH -------------------------- */
+group TransformVBCISHObservationRETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 20, 0,id_2183
+    //Phaenotyp -> 20, 0, id_2184
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 20, 0, id_2191
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 20;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2191';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 20, 0, id_2192
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                    observation->data.blockindex = 20;
+                    observation->data.groupindex = 0;
+                    observation->data.itemid     = 'id_2192';
+                    quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/* --------------------- Observation ROS1 CISH ------------------------- */
+group TransformVBCISHObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 17, 0,id_2211
+    //Phaenotyp -> 17, 0, id_2212
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 17, 0, id_2225
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 17;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2225';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 17, 0, id_2226
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                observation->data.blockindex = 17;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2226';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+
+    //Polysomie -> polysomie component -> 17, 0, id_2227
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
+            {
+                observation->data.blockindex = 17;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2227';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/* --------------------- Observation ALK FISH -------------------------- */
+group TransformVBFISHObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 3, 0,id_2098
+    //Phaenotyp -> 3, 0, id_2099
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 3, 0, id_2119
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 3;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2119';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 3, 0, id_2120
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                observation->data.blockindex = 3;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2120';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+
+    //Polysomie -> polysomie -> 3, 0, id_2121
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
+            {
+                observation->data.blockindex = 3;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2121';
+                quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/* --------------------- Observation MET FISH -------------------------- */
+group TransformVBFISHObservationMETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 6, 0,id_2132
+    //Phaenotyp -> 6, 0, id_2133
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 6, 0, id_2154
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 6;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2154';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Amplifikation -> amplification-level component -> 6, 0, id_2155
+    observation -> tgt.data as data then 
+    {
+        observation.component as component then
+        {
+            component.valueCodeableConcept where "code.coding.code = 'amplification-level'" then
+            {
+                component.valueCodeableConcept as valueCodeableConcept,
+                valueCodeableConcept.coding as coding then  
+                {
+                    observation-> data.blockindex = 6;
+                    observation-> data.groupindex = 0;
+                    observation-> data.itemid = 'id_2155';
+                    coding.code as code where "code = 'LA9193-9'" -> data.values as values, values.value = 'Amplifikation high-level';
+                    coding.code as code where "code = 'LA8982-6'" -> data.values as values, values.value = 'Amplifikation intermediate-level';
+                    coding.code as code where "code = 'LA9194-7'" -> data.values as values, values.value = 'Amplifikation low-level';
+                    coding.code as code where "code = 'LA32-8'" -> data.values as values, values.value = 'negativ';
+                    coding.code as code where "code = 'LA11884-6'" -> data.values as values, values.value = 'nicht auswertbar';
+                };
+            };
+        };
+    };
+    
+    //Prozentzahl an Zellen mit mehr als 15 MET-Signalen pro Zelle (Positiv ≥ 10 %) bei einer high-level Amplifikation
+    //15-met-ratio component -> 6, 0, id_2156
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = '15-met-ratio'" then
+            {
+                observation -> data.blockindex = 6;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2156';
+                quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+
+    //Prozentzahl an Zellen mit mehr als 5 MET-Signalen pro Zelle (Positiv ≥ 50 %) bei einer intermediate-level Amplifikation
+    //5-met-ratio component -> 6, 0, id_2157
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = '5-met-ratio'" then
+            {
+                observation -> data.blockindex = 6;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2157';
+                quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+    //Prozentzahl an Zellen mit mehr als 4 MET-Signalen pro Zelle (Positiv ≥ 40 %) bei einer low-level Amplifikation
+    //4-met-ratio component -> 6, 0, id_2158
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = '4-met-ratio'" then
+            {
+                observation -> data.blockindex = 6;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2158';
+                quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+    //Gezählte Tumorzellen
+    //gezaehlteTumorzellen component > 6, 0, id_2159
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'C0007584'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2159';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //MET Signale
+    //met-signale component -> 6, 0, id_2160
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'met-signal-count'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2160';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //CEN Signale
+    //CEN-signale  -> 6, 0, id_2161
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'cen-signal-count'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2161';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //Quotient MET/CEN7 Signale
+    //quot-met-cen-signal component -> 6, 0, id_2162
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'met-cen-signal-ratio'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2162';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //Durchschnitt MET-Genkopiezahl/Zelle (Positiv ≥ 6)
+    //met-copy-pro-zell component -> 6, 0, id_2163
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'met-copy-per-cell'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2163';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //Polysomie
+    //polysomie component -> 6, 0, id_2164
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
+            {
+                observation  -> data.blockindex = 6;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2164';
+                quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/* --------------------- Observation RET FISH -------------------------- */
+group TransformVBFISHObservationRETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+        
+    //Date of Assessment -> 20, 0,id_2183
+    //Phaenotyp -> 20, 0, id_2184
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 20, 0, id_2198
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 20;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2198';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 20, 0, id_2199
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                    observation -> data.blockindex = 20;
+                    observation -> data.groupindex = 0;
+                    observation -> data.itemid     = 'id_2199';
+                    quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+    //Polysomie
+    //polysomie component -> 20, 0, id_2200
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
+            {
+                    observation -> data.blockindex = 20;
+                    observation -> data.groupindex = 0;
+                    observation -> data.itemid     = 'id_2200';
+                    quantity.value as value -> data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/* --------------------- Observation ROS1 FISH ------------------------- */
+group TransformVBFISHObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 17, 0,id_2211
+    //Phaenotyp -> 17, 0, id_2212
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 17, 0, id_2233
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 17;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2233';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Positive Tumorzellen -> pos-tumor-zellen component -> 17, 0, id_2234
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
+            {
+                observation->data.blockindex = 17;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2234';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+    //Polysomie -> polysomie component -> 17, 0, id_2235
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
+            {
+                observation->data.blockindex = 17;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2235';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
+            };
+        };
+    };
+}
+
+/*----------------------------------------------------------------------
+                            Fusion NGS                                  
+------------------------------------------------------------------------ */
+group TransformVBObservationFSCDS(source observation: Observation, target tgt: BackboneElement, target index: RepeatIndex)
+{
+    observation where "code.coding.code = 'ALK'" then TransformVBFSObservationALKCDS(observation, tgt);
+    observation where "code.coding.code = 'RET'" then TransformVBFSObservationRETCDS(observation, tgt);
+    observation where "code.coding.code = 'ROS1'" then TransformVBFSObservationROS1CDS(observation, tgt);
+    observation where "code.coding.code = 'NTRK1'" then TransformVBFSObservationNTRK1CDS(observation, tgt);
+    observation where "code.coding.code = 'NTRK2'" then TransformVBFSObservationNTRK2CDS(observation, tgt);
+    observation where "code.coding.code = 'NTRK3'" then TransformVBFSObservationNTRK3CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR1'" then TransformVBFSObservationFGFR1CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR2'" then TransformVBFSObservationFGFR2CDS(observation, tgt);
+    observation where "code.coding.code = 'FGFR3'" then TransformVBFSObservationFGFR3CDS(observation, tgt);
+    observation where "code.coding.code = 'Sonstige Fusion NGS'" then TransformVBFSObservationSonstigeCDS(observation, tgt, index);
+}
+
+/* ------------------ Observation ALK FusionNGS ------------------------ */
+group TransformVBFSObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 3, 0,id_2098
+    //Phaenotyp -> 3, 0, id_2099
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
+
+    //Ergebnis -> 3, 0, id_2127
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 3;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2127';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 3, 0, id_2128
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 3;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2128';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 3, 0, id_2129
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 3;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2129';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 3, 0, id_2130
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 3;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2130';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //ALK Exon -> exon component -> 3, 0, id_2131
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
+            {
+                observation  -> data.blockindex = 3;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2131';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ------------------ Observation RET FusionNGS ------------------------ */
+group TransformVBFSObservationRETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 20, 0,id_2183
+    //Phaenotyp -> 20, 0, id_2184
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
+
+    //Ergebnis -> 20, 0, id_2206
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 20;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2206';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 20, 0, id_2207
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 20;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2207';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 20, 0, id_2208
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 20;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2208';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 20, 0, id_2209
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 20;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2209';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //RET Exon -> fusionspartner-exon component -> 20, 0, id_2210
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
+            {
+                observation  -> data.blockindex = 20;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2210';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ----------------- Observation ROS1 FusionNGS ------------------------ */
+group TransformVBFSObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 17, 0,id_2211
+    //Phaenotyp -> 17, 0, id_2212
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
+
+    //Ergebnis -> 17, 0, id_2241
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 17;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2241';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 17, 0, id_2242
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 17;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2242';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 17, 0, id_2243
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 17;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2243';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 17, 0, id_2244
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 17;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2244';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //ROS1 Exon -> fusionspartner-exon component -> 17, 0, id_2245
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
+            {
+                observation  -> data.blockindex = 17;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2245';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ----------------- Observation NTRK1 FusionNGS ----------------------- */
+group TransformVBFSObservationNTRK1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 8, 0, id_2540
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation->data.blockindex = 8;
+            observation->data.groupindex = 0;
+            observation->data.itemid     = 'id_2540';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Ergebnis -> 8, 0, id_2547
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 8;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2547';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 8, 0, id_2548
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 8;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2548';
+                valueString -> data.values as values,values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 8, 0, id_2549
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 8;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2549';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 8, 0, id_2550
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 8;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2550';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ----------------- Observation NTRK2 FusionNGS ----------------------- */
+group TransformVBFSObservationNTRK2CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 9, 0, id_2592
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex = 9;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2592';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Ergebnis -> 9, 0, id_2596
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 9;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2596';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 9, 0, id_2597
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 9;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2597';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 9, 0, id_2598
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 9;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2598';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 9, 0, id_2599
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 9;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2599';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ----------------- Observation NTRK3 FusionNGS ----------------------- */
+group TransformVBFSObservationNTRK3CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 10, 0, id_2584
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation->data.blockindex = 10;
+            observation->data.groupindex = 0;
+            observation->data.itemid     = 'id_2584';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Ergebnis -> 10, 0, id_2588
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 10;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2588';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 10, 0, id_2589
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 10;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2589';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 10, 0, id_2590
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 10;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2590';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 10, 0, id_2591
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 10;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2591';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ---------------- Observation FGFR1 FusionNGS ------------------------ */
+group TransformVBFSObservationFGFR1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 11, 0, id_2576
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation->data.blockindex = 11;
+            observation->data.groupindex = 0;
+            observation->data.itemid     = 'id_2576';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Ergebnis -> 11, 0, id_2580
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 11;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2580';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 11, 0, id_2581
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 11;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2581';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 11, 0, id_2582
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 11;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2582';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //5' Fusionspartner Exon -> fusionspartner-exon component -> 11, 0, id_2583
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 11;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2583';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ---------------- Observation FGFR2 FusionNGS ------------------------ */
+group TransformVBFSObservationFGFR2CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 12, 0, id_2568
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation->data.blockindex = 12;
+            observation->data.groupindex = 0;
+            observation->data.itemid     = 'id_2568';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Ergebnis -> 12, 0, id_2572
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 12;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2572';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 12, 0, id_2573
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 12;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2573';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 12, 0, id_2574
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 12;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2574';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //3' Fusionspartner Exon -> fusionspartner-exon component -> 12, 0, id_2575
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 12;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2575';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ---------------- Observation FGFR3 FusionNGS ------------------------ */
+group TransformVBFSObservationFGFR3CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 13, 0, id_2560
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex = 13;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2560';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Ergebnis -> 13, 0, id_2564
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 13;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2564';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+    
+    //Fusionspartner -> fusionspartner component -> 13, 0, id_2565
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C28510'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex = 13;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2565';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 13, 0, id_2566
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex = 13;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2566';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+    //3' Fusionspartner Exon -> fusionspartner-exon component -> 13, 0, id_2567
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
+            {
+                observation  -> data.blockindex = 13;
+                observation  -> data.groupindex = 0;
+                observation  -> data.itemid     = 'id_2567';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+}
+
+/* ------------- Observation Sonstiges FusionNGS ----------------------- */
+group TransformVBFSObservationSonstigeCDS(source observation: Observation, target tgt: BackboneElement, target index: RepeatIndex)
+{
+    //Date Of Assesment -> 21, 0, id_2246
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex  = 21;
+            observation -> data.groupindex  = 0;
+            observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
+            observation -> data.itemid      = 'id_2246';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Ergebnis -> 21, 0, id_2254
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding then
+        {
+            observation->data.blockindex = 21;
+            observation->data.groupindex = 0;
+            observation->data.repeatindex = evaluate(index, '$this.caseIndex');
+            observation->data.itemid = 'id_2254';
+            coding.code as code where "code = 'LA6576-8'" -> data.values as values, values.value = 'positiv';
+            coding.code as code where "code = 'LA6577-6'" -> data.values as values, values.value = 'negativ';
+            coding.code as code where "code = 'LA18198-4'" -> data.values as values, values.value = 'nicht auswertbar';
+        };
+    };
+
+    // Erster Fusionspartner -> 21, 0 , id_2255 if 1 (or more) components with this code
+    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 1" -> tgt.data as data then
+    {
+        observation->data.blockindex = 21;
+        observation->data.groupindex = 0;
+        observation->data.repeatindex = evaluate(index, '$this.caseIndex');
+        observation->data.itemid = 'id_2255';
+        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[0].valueString');
+    };
+
+    // Zweiter Fusionspartner -> 21, 0 , id_2256 if 2 (or more) components with this code
+    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 2" -> tgt.data as data then
+    {
+        observation->data.blockindex = 21;
+        observation->data.groupindex = 0;
+        observation->data.repeatindex = evaluate(index, '$this.caseIndex');
+        observation->data.itemid = 'id_2256';
+        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[1].valueString');
+    };
+
+    //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 21, 0, id_2257
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex  = 21;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.caseIndex');
+                observation  -> data.itemid      = 'id_2257';
+                valueInteger -> data.values as values, values.unit = 'count', values.value = valueInteger;
+            };
+        };
+    };
+
+    //Exon erster Fusionspartner -> exon-erster-fusionspartner component -> 21, 0, id_2258
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'erster-fusionspartner-exon'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 21;
+                observation -> data.groupindex  = 0;
+                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
+                observation -> data.itemid      = 'id_2258';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+
+    //Exon zweiter Fusionspartner -> exon-zweiter-fusionspartner component -> 21, 0, id_2259
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'zweiter-fusionspartner-exon'" then
+        {
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 21;
+                observation -> data.groupindex  = 0;
+                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
+                observation -> data.itemid      = 'id_2259';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+}
 
 
 
 group Rest(source entry: BackboneElement, target tgt: BackboneElement, target index: RepeatIndex)
 {
- 
-    /*---------------------------------------------------------------------
-                    Chromogenic in-situ-Hybridisierung (CISH)               
-    ------------------------------------------------------------------------ */
-    /* --------------------- Observation ALK CISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ALK'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'" then
-    {
-        //Date of Assessment -> 3, 0,id_2098
-        //Phaenotyp -> 3, 0, id_2099
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
 
-        //Ergebnis -> 3, 0, id_2112
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2112';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2112';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2112';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 3, 0, id_2113
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2113';
-                    quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation MET CISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'MET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'" then
-    {
-        //Date of Assessment -> 6, 0,id_2132
-        //Phaenotyp -> 6, 0, id_2133
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 6, 0, id_2147
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2147';
-                        code -> data.values as values, 
-                                values.value   = 'positiv (high-level amplification)';
-            };
-
-                observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA11884-6'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2147';
-                        code -> data.values as values, 
-                                values.value   = 'positiv (moderate-level amplification)';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2147';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2147';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Amplifikation -> amplification-level component -> 6, 0, id_2148
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.code where "code.coding.code = 'amplification-level'" then
-                {
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA6576-8'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2148';
-                        code.value as value -> data.values as values,  
-                                            values.value = 'Amplifikation high-level';
-                    };
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA11884-6'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2148';
-                        code.value as value ->data.values as values,  
-                                            values.value = 'Amplifikation moderate-level';
-                    };
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA32-8'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2148';
-                        code.value as value ->data.values as values,  
-                                            values.value = 'keine Amplifikation';
-                    };
-                };
-            };
-        };
-    };
-    /* --------------------- Observation RET CISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'RET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'" then
-    {
-        //Date of Assessment -> 20, 0,id_2183
-        //Phaenotyp -> 20, 0, id_2184
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 20, 0, id_2191
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2191';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2191';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2191';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 20, 0, id_2192
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                        observation->data.blockindex = 20;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid     = 'id_2192';
-                        quantity.value as value ->data.values as values, 
-                                            values.unit = 'percent', 
-                                        values.value = value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation ROS1 CISH ------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ROS1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'" then
-    {
-        //Date of Assessment -> 17, 0,id_2211
-        //Phaenotyp -> 17, 0, id_2212
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 17, 0, id_2225
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2225';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2225';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2225';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 17, 0, id_2226
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2226';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-        //Polysomie -> polysomie component -> 17, 0, id_2227
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2227';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-    };
-    /*----------------------------------------------------------------------
-                    Fluoreszenz-in-situ-Hybridisierung (FISH)               
-    ------------------------------------------------------------------------ */
-    /* --------------------- Observation ALK FISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ALK'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'" then
-    {
-        //Date of Assessment -> 3, 0,id_2098
-        //Phaenotyp -> 3, 0, id_2099
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 3, 0, id_2119
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2119';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2119';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2119';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 3, 0, id_2120
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2120';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-        //Polysomie -> polysomie -> 3, 0, id_2121
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2121';
-                    quantity.value as value -> data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation MET FISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'MET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'" then
-    {
-        observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
-        //Ergebnis -> 6, 0, id_2154
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2154';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2154';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2154';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Amplifikation -> amplification-level component -> 6, 0, id_2155
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.code where "code.coding.code = 'amplification-level'" then
-                {
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA6576-8'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2155';
-                        code.value as value ->data.values as values,  
-                                            values.value = 'Amplifikation high-level';
-                    };
-
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA11884-6'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2155';
-                        code.value as value ->data.values as values,  
-                                            values.value = 'Amplifikation intermediate-level';
-                    };
-
-                    //TODO:Please verify the value code to change to right  value
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA32-8'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2155';
-                        code.value as value -> data.values as values,  
-                                            values.value = 'Amplifikation low-level';
-                    };
-
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA6577-6'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2155';
-                        code.value as value -> data.values as values,  
-                                            values.value = 'negativ';
-                    };
-
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, 
-                    coding.code as code where "code ='LA18198-4'" then 
-                    {
-                        observation -> data.blockindex = 6;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2155';
-                        code.value as value -> data.values as values,  
-                                            values.value = 'nicht auswertbar';
-                    };
-                };
-            };
-        };
-        //Prozentzahl an Zellen mit mehr als 15 MET-Signalen pro Zelle (Positiv ≥ 10 %) bei einer high-level Amplifikation
-        //15-met-ratio component -> 6, 0, id_2156
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = '15-met-ratio'" then
-                {
-                    observation -> data.blockindex = 6;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2156';
-                    quantity.value as value -> data.values as values, 
-                                    values.unit    = 'percent', 
-                                    values.value   =  value;
-                };
-            };
-        };
-        //Prozentzahl an Zellen mit mehr als 5 MET-Signalen pro Zelle (Positiv ≥ 50 %) bei einer intermediate-level Amplifikation
-        //5-met-ratio component -> 6, 0, id_2157
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = '5-met-ratio'" then
-                {
-                    observation -> data.blockindex = 6;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2157';
-                    quantity.value as value -> data.values as values, 
-                                    values.unit    = 'percent', 
-                                    values.value   =  value;
-                };
-            };
-        };
-        //Prozentzahl an Zellen mit mehr als 4 MET-Signalen pro Zelle (Positiv ≥ 40 %) bei einer low-level Amplifikation
-        //4-met-ratio component -> 6, 0, id_2158
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = '4-met-ratio'" then
-                {
-                    observation -> data.blockindex = 6;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2158';
-                    quantity.value as value -> data.values as values, 
-                                    values.unit    = 'percent', 
-                                    values.value   =  value;
-                };
-            };
-        };
-        //Gezählte Tumorzellen
-        //gezaehlteTumorzellen component > 6, 0, id_2159
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'C0007584'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2159';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //MET Signale
-        //met-signale component -> 6, 0, id_2160
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'met-signal-count'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2160';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //CEN Signale
-        //CEN-signale  -> 6, 0, id_2161
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'cen-signal-count'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2161';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //Quotient MET/CEN7 Signale
-        //quot-met-cen-signal component -> 6, 0, id_2162
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'met-cen-signal-ratio'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2162';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //Durchschnitt MET-Genkopiezahl/Zelle (Positiv ≥ 6)
-        //met-copy-pro-zell component -> 6, 0, id_2163
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'met-copy-per-cell'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2163';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //Polysomie
-        //polysomie component -> 6, 0, id_2164
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2164';
-                    quantity.value as value -> data.values as values, 
-                                    values.unit     = 'percent', 
-                                    values.value    =  value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation RET FISH -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'RET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'" then
-    {
-        
-        //Date of Assessment -> 20, 0,id_2183
-        //Phaenotyp -> 20, 0, id_2184
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 20, 0, id_2198
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2198';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2198';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2198';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 20, 0, id_2199
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                        observation -> data.blockindex = 20;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2199';
-                        quantity.value as value -> data.values as values, 
-                                            values.unit = 'percent', 
-                                            values.value = value;
-                };
-            };
-        };
-        //Polysomie
-        //polysomie component -> 20, 0, id_2200
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
-                {
-                        observation -> data.blockindex = 20;
-                        observation -> data.groupindex = 0;
-                        observation -> data.itemid     = 'id_2200';
-                        quantity.value as value -> data.values as values, 
-                                            values.unit = 'percent', 
-                                            values.value = value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation ROS1 FISH ------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ROS1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'" then
-    {
-        //Date of Assessment -> 17, 0,id_2211
-        //Phaenotyp -> 17, 0, id_2212
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 17, 0, id_2233
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2233';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2233';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2233';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Positive Tumorzellen -> pos-tumor-zellen component -> 17, 0, id_2234
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C70460'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2234';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-        //Polysomie -> polysomie component -> 17, 0, id_2235
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C36331'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2235';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-    };
-    /*----------------------------------------------------------------------
-                                Fusion NGS                                  
-    ------------------------------------------------------------------------ */
-    /* ------------------ Observation ALK FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ALK'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date of Assessment -> 3, 0,id_2098
-        //Phaenotyp -> 3, 0, id_2099
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
-
-        //Ergebnis -> 3, 0, id_2127
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2127';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2127';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2127';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 3, 0, id_2128
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 3;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2128';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 3, 0, id_2129
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 3;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2129';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 3, 0, id_2130
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 3;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2130';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //ALK Exon -> exon component -> 3, 0, id_2131
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
-                {
-                    observation  -> data.blockindex = 3;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2131';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ------------------ Observation RET FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'RET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date of Assessment -> 20, 0,id_2183
-        //Phaenotyp -> 20, 0, id_2184
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationRETDatePhanotypVorbefund(observation, tgt);
-
-        //Ergebnis -> 20, 0, id_2206
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2206';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2206';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 20;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2206';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 20, 0, id_2207
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 20;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2207';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 20, 0, id_2208
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 20;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2208';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 20, 0, id_2209
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 20;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2209';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //RET Exon -> fusionspartner-exon component -> 20, 0, id_2210
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
-                {
-                    observation  -> data.blockindex = 20;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2210';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ----------------- Observation ROS1 FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ROS1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date of Assessment -> 17, 0,id_2211
-        //Phaenotyp -> 17, 0, id_2212
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
-
-        //Ergebnis -> 17, 0, id_2241
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2241';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2241';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2241';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 17, 0, id_2242
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 17;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2242';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 17, 0, id_2243
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 17;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2243';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 17, 0, id_2244
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 17;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2244';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //ROS1 Exon -> fusionspartner-exon component -> 17, 0, id_2245
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'C13231'" then
-                {
-                    observation  -> data.blockindex = 17;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2245';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ----------------- Observation NTRK1 FusionNGS ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'NTRK1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 8, 0, id_2540
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation->data.blockindex = 8;
-                observation->data.groupindex = 0;
-                observation->data.itemid     = 'id_2540';
-                period as dateOfAssessment-> data.values as values, 
-                                values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 8, 0, id_2547
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 8;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2547';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 8;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2547';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 8;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2547';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 8, 0, id_2548
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 8;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2548';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 8, 0, id_2549
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 8;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2549';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 8, 0, id_2550
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 8;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2550';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ----------------- Observation NTRK2 FusionNGS ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'NTRK2'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 9, 0, id_2592
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 9;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2592';
-                period as dateOfAssessment-> data.values as values,
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 9, 0, id_2596
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 9;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2596';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 9;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2596';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 9;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2596';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 9, 0, id_2597
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 9;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2597';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 9, 0, id_2598
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 9;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2598';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 9, 0, id_2599
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 9;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2599';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ----------------- Observation NTRK3 FusionNGS ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'NTRK3'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 10, 0, id_2584
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation->data.blockindex = 10;
-                observation->data.groupindex = 0;
-                observation->data.itemid     = 'id_2584';
-                period as dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 10, 0, id_2588
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 10;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2588';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 10;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2588';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 10;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2588';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 10, 0, id_2589
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 10;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2589';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 10, 0, id_2590
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 10;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2590';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 10, 0, id_2591
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 10;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2591';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ---------------- Observation FGFR1 FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'FGFR1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 11, 0, id_2576
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation->data.blockindex = 11;
-                observation->data.groupindex = 0;
-                observation->data.itemid     = 'id_2576';
-                period as dateOfAssessment-> data.values as values, 
-                                values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 11, 0, id_2580
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 11;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2580';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 11;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2580';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 11;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2580';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 11, 0, id_2581
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 11;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2581';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 11, 0, id_2582
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 11;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2582';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //5' Fusionspartner Exon -> fusionspartner-exon component -> 11, 0, id_2583
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 11;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2583';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ---------------- Observation FGFR2 FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'FGFR2'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 12, 0, id_2568
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation->data.blockindex = 12;
-                observation->data.groupindex = 0;
-                observation->data.itemid     = 'id_2568';
-                period as dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 12, 0, id_2572
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 12;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2572';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 12;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2572';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 12;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2572';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 12, 0, id_2573
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 12;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2573';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 12, 0, id_2574
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 12;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2574';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //3' Fusionspartner Exon -> fusionspartner-exon component -> 12, 0, id_2575
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 12;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2575';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ---------------- Observation FGFR3 FusionNGS ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'FGFR3'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 13, 0, id_2560
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 13;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2560';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 13, 0, id_2564
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 13;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2564';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 13;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2564';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 13;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2564';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Fusionspartner -> fusionspartner component -> 13, 0, id_2565
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C28510'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 13;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2565';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 13, 0, id_2566
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex = 13;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2566';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-        //3' Fusionspartner Exon -> fusionspartner-exon component -> 13, 0, id_2567
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = 'fusionspartner-exon'" then
-                {
-                    observation  -> data.blockindex = 13;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2567';
-                    valueInteger -> data.values as values, 
-                                    values.unit     = 'count', 
-                                    values.value    =  valueInteger;
-                };
-            };
-        };
-    };
-    /* ------------- Observation Sonstiges FusionNGS ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'Sonstiges'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-    {
-        //Date Of Assesment -> 21, 0, 0, id_2246
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex  = 21;
-                observation -> data.groupindex  = 0;
-                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                observation -> data.itemid      = 'id_2246';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Ergebnis -> 21, 0, 0, id_2254
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex  = 21;
-                observation -> data.groupindex  = 0;
-                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                observation -> data.itemid      = 'id_2254';
-                        code -> data.values as values, 
-                                values.value    = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex  = 21;
-                observation -> data.groupindex  = 0;
-                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                observation -> data.itemid      = 'id_2254';
-                        code -> data.values as values, 
-                                values.value    = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex  = 21;
-                observation -> data.groupindex  = 0;
-                observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                observation -> data.itemid      = 'id_2254';
-                        code -> data.values as values,
-                                values.value    = 'nicht auswertbar';
-            };
-        };
-        //Erster Fusionspartner -> erster-fusionspartner component -> 21, 0, id_2255
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48018-6'" then
-            {
-                component.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding, coding.code as code  then
-                {
-                    observation -> data.blockindex  = 21;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                    observation -> data.itemid      = 'id_2255';
-                        code   -> data.values as values,
-                                    values.value    = code;
-                };
-            };
-        };
-        //Zweiter Fusionspartner -> fusionspartner component -> 21, 0, id_2256
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueString as valueString where "code.coding.code = 'C28510'" then
-                {
-                    observation  -> data.blockindex  = 21;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                    observation  -> data.itemid      = 'id_2256';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
-            };
-        };
-        //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 21, 0, id_2257
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueInteger as valueInteger where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex  = 21;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                    observation  -> data.itemid      = 'id_2257';
-                    valueInteger -> data.values as values, 
-                                    values.unit      = 'count', 
-                                    values.value     =  valueInteger;
-                };
-            };
-        };
-
-        //Exon erster Fusionspartner -> exon-erster-fusionspartner component -> 21, 0, id_2258
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'erster-fusionspartner-exon'" then
-            {
-                component.valueInteger as code then
-                {
-                    observation -> data.blockindex  = 21;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                    observation -> data.itemid      = 'id_2258';
-                        code   -> data.values as values,
-                                    values.value    = code;
-                };
-            };
-        };
-
-        //Exon zweiter Fusionspartner -> exon-zweiter-fusionspartner component -> 21, 0, id_2259
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'zweiter-fusionspartner-exon'" then
-            {
-                component.valueInteger as code then
-                {
-                    observation -> data.blockindex  = 21;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.caseIndex');
-                    observation -> data.itemid      = 'id_2259';
-                        code   -> data.values as values,
-                                    values.value    = code;
-                };
-            };
-        };
-    };
     /*------------------------------------------------------------------------------
                                 Fast Track                                  
     ------------------------------------------------------------------------------*/
@@ -2580,13 +2057,13 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
             observation.component as component, 
             component.code where "code.coding.code = '48004-6'" then
             {
-                component.valueString as value  then
+                component.valueString as valueString then
                 {
                     observation -> data.blockindex = 22;
                     observation -> data.groupindex = 0;
                     observation -> data.itemid     = 'id_1947';
-                        value   -> data.values as values,
-                                    values.value   = value;
+                    valueString -> data.values as values,
+                                    values.value   = valueString;
                 };
             };
         };
@@ -2637,13 +2114,13 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
             observation.component as component, 
             component.code where "code.coding.code = '48004-6'" then
             {
-                component.valueString as value  then
+                component.valueString as valueString then
                 {
                     observation -> data.blockindex = 23;
                     observation -> data.groupindex = 0;
                     observation -> data.itemid     = 'id_1951';
-                        value   -> data.values as values,
-                                    values.value   = value;
+                    valueString -> data.values as values,
+                                    values.value   = valueString;
                 };
             };
         };
@@ -2694,13 +2171,13 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
             observation.component as component, 
             component.code where "code.coding.code = '48004-6'" then
             {
-                component.valueString as value  then
+                component.valueString as valueString then
                 {
                     observation -> data.blockindex = 23;
                     observation -> data.groupindex = 0;
                     observation -> data.itemid     = 'id_1955';
-                        value   -> data.values as values,
-                                    values.value   = value;
+                    valueString -> data.values as values,
+                                    values.value   = valueString;
                 };
             };
         };
@@ -2751,13 +2228,13 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
             observation.component as component, 
             component.code where "code.coding.code = '48004-6'" then
             {
-                component.valueString as value  then
+                component.valueString as valueString then
                 {
                     observation -> data.blockindex = 23;
                     observation -> data.groupindex = 0;
                     observation -> data.itemid     = 'id_1959';
-                        value   -> data.values as values,
-                                    values.value   = value;
+                    valueString -> data.values as values,
+                                    values.value   = valueString;
                 };
             };
         };
@@ -2814,13 +2291,13 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
             observation.component as component, 
             component.code where "code.coding.code = '48004-6'" then
             {
-                component.valueString as value  then
+                component.valueString as valueString then
                 {
                     observation -> data.blockindex = 24;
                     observation -> data.groupindex = 0;
                     observation -> data.itemid     = 'id_1963';
-                        value   -> data.values as values,
-                                    values.value   = value;
+                    valueString -> data.values as values,
+                                    values.value   = valueString;
                 };
             };
         };

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -1,12 +1,6 @@
 /// version = 0.1
 /// title = "nNGM_Mapping_VorbefundCTS"
 
-/* 
-    TODO
-    - "Sonstige Fusion NGS" Observation: if there is only 1 "Fusionspartner" given, it gets mapped to the "Erster Fusionspartner" (id_2255) even if it was entered 
-        in the "Zweiter Fusionspartner" field. This behaviour is because both components for the Fusionspartner are using the same code (48018-6)
-*/
-
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundCDS" = nNGM_Mapping_VorbefundCDS
 
 uses "http://hl7.org/fhir/StructureDefinition/Bundle" as source
@@ -1958,24 +1952,26 @@ group TransformVBFSObservationSonstigeCDS(source observation: Observation, targe
         };
     };
 
-    // Erster Fusionspartner -> 21, 0 , id_2255 if 1 (or more) components with this code
-    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 1" -> tgt.data as data then
+    // Erster/Zweiter Fusionspartner -> 21, 0 , id_2255/id_2556
+    observation.component as component where "component.where(code.coding.where(code = '48018-6'))" then
     {
-        observation->data.blockindex = 21;
-        observation->data.groupindex = 0;
-        observation->data.repeatindex = evaluate(index, '$this.caseIndex');
-        observation->data.itemid = 'id_2255';
-        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[0].valueString');
-    };
+        component as ersterFusionspartner where "code.coding.where(code = 'erster-fusionspartner') and valueString.exists()" -> tgt.data as data then
+        {
+            observation->data.blockindex = 21;
+            observation->data.groupindex = 0;
+            observation->data.repeatindex = evaluate(index, '$this.caseIndex');
+            observation->data.itemid = 'id_2255';
+            ersterFusionspartner.valueString as valueString ->data.values as values, values.value = valueString;
+        };
 
-    // Zweiter Fusionspartner -> 21, 0 , id_2256 if 2 (or more) components with this code
-    observation where "$this.component.where(code.coding.code = '48018-6' and valueString.exists()).count() >= 2" -> tgt.data as data then
-    {
-        observation->data.blockindex = 21;
-        observation->data.groupindex = 0;
-        observation->data.repeatindex = evaluate(index, '$this.caseIndex');
-        observation->data.itemid = 'id_2256';
-        observation->data.values as values, values.value = evaluate(observation, '$this.component.where(code.coding.code = \'48018-6\')[1].valueString');
+        component as zweiterFusionspartner where "code.coding.where(code = 'zweiter-fusionspartner') and valueString.exists()" -> tgt.data as data then
+        {
+            observation->data.blockindex = 21;
+            observation->data.groupindex = 0;
+            observation->data.repeatindex = evaluate(index, '$this.caseIndex');
+            observation->data.itemid = 'id_2256';
+            zweiterFusionspartner.valueString as valueString ->data.values as values, values.value = valueString;
+        };
     };
 
     //Anzahl der Fusionsreads -> anzahl-der-fusionsreads component -> 21, 0, id_2257

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -14,12 +14,26 @@ group TransformVorbefundCDS(source entry: BackboneElement, target tgt: BackboneE
     entry.resource as diagnosticReport where "resource is DiagnosticReport and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund'" 
         then TransformVBDiagnosticReportCDS(diagnosticReport, tgt);
 
-    entry.resource as observationHL where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie'" 
+    // Histologie
+    entry.resource as observationHL where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie'" 
         then TransformVBObservationHistologieCDS(observationHL, tgt);
 
+    // Immunhistochemie
     entry.resource as observationIHC where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'"
         then TransformVBObservationIHCCDS(observationIHC, tgt);
 
+    // Molekularpathologie
+    // entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ish'"
+    //     then TransformVBCISHObservationCDS(observation, tgt);
+
+    // entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fish'"
+    //     then TransformVBFISHObservationCDS(observation, tgt);
+
+    // Fusion NGS 
+
+    // Fast Track 
+
+    // NGS Lung Panel  
 }
 
 /* ------------------------------ Specimen ---------------------------- */
@@ -2833,15 +2847,6 @@ group Rest(source entry: BackboneElement, target tgt: BackboneElement, target in
     /* --------------------- Device NGSPanel Fusion NGS -------------------- */
     entry.resource as device where "resource is Device and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device'" then
     {
-        //NGS Panel -> 2, 0, id_2513
-        device -> tgt.data as data then
-        {
-            device -> data.blockindex = 2;
-            device -> data.groupindex = 0;
-            device -> data.itemid     = 'id_2513';
-            device  -> data.values as values, 
-                            values.value = 'yes';
-        };
         //NGS Lung Panel Version -> 25, 0, id_1260
         device -> tgt.data as data then
         {

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -15,1032 +15,643 @@ uses "http://hl7.org/fhir/StructureDefinition/CTS_Transport" as target
 
 group TransformVorbefundCDS(source entry: BackboneElement, target tgt: BackboneElement, target index: RepeatIndex)
 {
-    /* ------------------------------ Specimen ---------------------------- */
-    entry.resource as specimen where "resource is Specimen and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Specimen/nNGM'" then
+    entry.resource as specimen where "resource is Specimen and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Specimen/nNGM'" 
+        then TransformVBSpecimenCDS(specimen, tgt);
+
+    entry.resource as diagnosticReport where "resource is DiagnosticReport and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund'" 
+        then TransformVBDiagnosticReportCDS(diagnosticReport, tgt);
+
+    entry.resource as observationHL where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nNGM/histologie'" 
+        then TransformVBObservationHistologieCDS(observationHL, tgt);
+
+    entry.resource as observationIHC where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'"
+        then TransformVBObservationIHCCDS(observationIHC, tgt);
+
+}
+
+/* ------------------------------ Specimen ---------------------------- */
+group TransformVBSpecimenCDS(source specimen: Specimen, target tgt: BackboneElement)
+{
+    //Eingang des Tumormaterials am nNGM-Standort -> 0, 0, id_2471
+    specimen -> tgt.data as data then
     {
-        //Biopsy-ID -> 27, 0, id_1601
-        specimen -> tgt.data as data then
+        specimen.receivedTime as rt then
+        {   
+            specimen -> data.blockindex  = 0;
+            specimen -> data.groupindex  = 0;
+            specimen -> data.itemid      = 'id_2471';
+            rt -> data.values as values, values.value = rt;
+        };
+    };  
+}
+
+/* -------------------------- DiagnosticReport ------------------------ */
+group TransformVBDiagnosticReportCDS(source diagnosticReport: DiagnosticReport, target tgt: BackboneElement)
+{
+    //Befunddatum -> 0, 0, id_1653
+    diagnosticReport -> tgt.data as data then
+    {
+        diagnosticReport.issued as issued then
+        {   
+            diagnosticReport -> data.blockindex  = 0;
+            diagnosticReport -> data.groupindex  = 0;
+            diagnosticReport -> data.itemid      = 'id_1653';
+            issued -> data.values as values, values.value = issued;
+        };
+    };                
+    //Befundnummer -> 0, 0, id_1654
+    diagnosticReport -> tgt.data as data then
+    {
+        diagnosticReport.identifier as identifier,
+            identifier.system as system where "system = 'http://uk-koeln.de/NamingSystem/nNGM/befundnummer'" then
+        {   
+            diagnosticReport -> data.blockindex  = 0;
+            diagnosticReport -> data.groupindex  = 0;
+            diagnosticReport -> data.itemid      = 'id_1654';
+            identifier.value as value-> data.values as values, values.value = value;
+        };
+    };                
+}
+
+/* ---------------------- ObservationHistologie ----------------------- */
+group TransformVBObservationHistologieCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Klassifikation -> klassifikation component -> 1, 0,  id_1658
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C25161'" then
         {
-            specimen.identifier as identifier then
-            {   
-                specimen -> data.blockindex  = 27;
-                specimen -> data.groupindex  = 0;
-                specimen -> data.itemid      = 'id_1601';
-                identifier.value as value-> data.values as values, 
-                                values.unit  = 'count', 
+            component.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding, coding.code as code then 
+            {
+                observation -> data.blockindex  = 1;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1658';
+                code -> data.values as values, values.value = code;
+            };
+        };
+    };
+
+    //Lokalisation -> 1, 0, id_2469
+    observation -> tgt.data as data then
+    {
+        observation.bodySite as bodySite where "$this.bodySite.coding.system = 'urn:oid:2.16.840.1.113883.6.43.1'", 
+        bodySite.coding as coding then
+        {   
+            observation -> data.blockindex = 1;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2469';
+            coding.code as code -> data.values as values, values.value = code;
+        };
+    };
+
+    //Grading -> 1, 0, id_2403
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as cc, cc.coding as coding then
+        {   
+            observation -> data.blockindex = 1;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2403';
+            coding.code as code -> data.values as values, values.value = code;
+        };
+    };
+}
+
+/*---------------------------------------------------------------------
+                            Immunhistochemie (IHC)                         
+----------------------------------------------------------------------- */
+group TransformVBObservationIHCCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    observation where "code.coding.code = 'BRAF'" then TransformVBObservationBRAFCDS(observation, tgt);
+    observation where "code.coding.code = 'CK7'" then TransformVBObservationCK7CDS(observation, tgt);
+    observation where "code.coding.code = 'MIB1'" then TransformVBObservationMIB1CDS(observation, tgt);
+    observation where "code.coding.code = 'Napsin A'" then TransformVBObservationNapsinACDS(observation, tgt);
+    observation where "code.coding.code = 'P40'" then TransformVBObservationP40CDS(observation, tgt);
+    observation where "code.coding.code = 'Synaptophysin'" then TransformVBObservationSynaptophysinCDS(observation, tgt);
+    observation where "code.coding.code = 'TTF1'" then TransformVBObservationTTF1CDS(observation, tgt);
+    observation where "code.coding.code = 'ALK'" then TransformVBObservationALKCDS(observation, tgt);
+    observation where "code.coding.code = 'MET'" then TransformVBObservationMETCDS(observation, tgt);
+    observation where "code.coding.code = 'PD-L1'" then TransformVBObservationPDL1CDS(observation, tgt);
+    observation where "code.coding.code = 'ROS1'" then TransformVBObservationROS1CDS(observation, tgt);
+}
+
+/* ---------------------- Observation BRAF IHC ------------------------ */
+group TransformVBObservationBRAFCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 4, 0, braf_ihc_group
+    observation.effectiveDateTime as dateOfAssessment -> tgt.data as data then
+    {
+        observation -> data.blockindex = 4;
+        observation -> data.groupindex = 0;
+        observation -> data.itemid     = 'braf_ihc_group';
+        dateOfAssessment -> data.values as values, values.value = dateOfAssessment;
+    };
+    //Phänotyp: phanotyp component-> 4, 0, braf_ihc_phaenotype
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 4;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'braf_ihc_phaenotype';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 4, 0, braf_ihc_result
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 4;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'braf_ihc_result';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* ---------------------- Observation CK7 IHC ------------------------ */
+group TransformVBObservationCK7CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 5, 0, id_2037
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex = 5;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2037';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 5, 0, id_2038
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 5;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2038';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 5, 0, id_2045
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 5;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2045';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* --------------------- Observation MIB1 IHC ------------------------ */
+group TransformVBObservationMIB1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 7, 0, id_2055
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation->data.blockindex = 7;
+            observation->data.groupindex = 0;
+            observation->data.itemid     = 'id_2055';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 7, 0, id_2056
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 7;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2056';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 7, 0, id_2063
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 7;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2063';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* ------------------ Observation Napsin A IHC ----------------------- */
+group TransformVBObservationNapsinACDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 14, 0, id_2064
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex   = 14;
+            observation -> data.groupindex   = 0;
+            observation -> data.itemid       = 'id_2064';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 14, 0, id_2065
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 14;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2065';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 14, 0, id_2072
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 14;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2072';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* ---------------------- Observation P40 IHC ------------------------ */
+group TransformVBObservationP40CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 15, 0, id_2073
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex   = 15;
+            observation -> data.groupindex   = 0;
+            observation -> data.itemid       = 'id_2073';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 15, 0, id_2074
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 15;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2074';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 15, 0, id_2079
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 15;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2079';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* ----------------- Observation Synaptophysin IHC -------------------- */
+group TransformVBObservationSynaptophysinCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 18, 0, id_2080
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex = 18;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2080';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 18, 0, id_2081
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 18;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2081';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 18, 0, id_2088
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 18;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2088';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* --------------------- Observation TTF1 IHC ------------------------- */
+group TransformVBObservationTTF1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 19, 0, id_2089
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex   = 19;
+            observation -> data.groupindex   = 0;
+            observation -> data.itemid       = 'id_2089';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+    //Phänotyp: phanotyp component-> 19, 0, id_2090
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 19;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2090';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 19, 0, id_2097
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 19;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2097';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* --------------------- Observation ALK IHC -------------------------- */
+group TransformVBObservationALKCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 3, 0,id_2098
+    //Phaenotyp -> 3, 0, id_2099 
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 3, 0, id_2106
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 3;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2106';
+            code->data.values as values, values.value = code;
+        };
+    };
+}
+
+/* --------------------- Observation MET IHC -------------------------- */
+group TransformVBObservationMETCDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 6, 0,id_2132
+    //Phaenotyp -> 6, 0, id_2133
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
+
+    //Ergebnis -> 6, 0, id_2139
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 6;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2139';
+            code->data.values as values, values.value = code;
+        };
+    };
+
+    //Klassifikation -> Klassifikation component -> 6, 0, id_2140
+    observation -> tgt.data as data then
+    {
+        observation.component as component,
+        component.code where "code.coding.code = 'C25161'" then
+        {
+            component.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then 
+            {
+                observation -> data.blockindex = 6;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2140';
+                code -> data.values as values, values.value = code;
+            };
+        };
+    };
+
+    //Expression high-level -> expression-high-level component -> 6, 0, id_2141
+    observation -> tgt.data as data then
+    {
+        observation.component as component,
+        component.code where "code.coding.code = 'C129474'" then
+        {
+            observation  -> data.blockindex = 6;
+            observation  -> data.groupindex = 0;
+            observation  -> data.itemid     = 'id_2141';
+            component.valueBoolean as valueBoolean where "valueBoolean = false" -> data.values as values, values.value = 'no';
+            component.valueBoolean as valueBoolean where "valueBoolean = true" -> data.values as values, values.value = 'yes';
+        };
+    };
+}
+
+/* --------------------- Observation PD-L1 IHC ------------------------- */
+group TransformVBObservationPDL1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 16, 0, id_2172
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as dateOfAssessment then
+        {
+            observation -> data.blockindex = 16;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_2172';
+            dateOfAssessment-> data.values as values, values.value = dateOfAssessment;
+        };
+    };
+
+    //Phänotyp: phanotyp component-> 16, 0, id_2173
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
+        {
+            component.valueCodeableConcept as vcc then
+            {
+                observation -> data.blockindex = 16;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2173';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
+            };
+        };
+    };
+
+    //Ergebnis -> 16, 0, id_2180
+    observation->tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation->data.blockindex = 16;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2180';
+            code->data.values as values, values.value = code;
+        };
+    };
+
+    //Menge der Tumorzellen (% positive Tumorzellen TPS) -> menge-tumorzellen component -> 16, 0, id_2181
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueQuantity as quantity where "code.coding.code = 'C127771'" then
+            {
+                observation->data.blockindex = 16;
+                observation->data.groupindex = 0;
+                observation->data.itemid     = 'id_2181';
+                quantity.value as value ->data.values as values, 
+                                values.unit  = 'percent', 
                                 values.value = value;
             };
         };
-
-        //Eingang des Tumormaterials am nNGM-Standort -> 0, 0, id_2471
-        specimen -> tgt.data as data then
-        {
-            specimen.receivedTime as rt then
-            {   
-                specimen -> data.blockindex  = 0;
-                specimen -> data.groupindex  = 0;
-                specimen -> data.itemid      = 'id_2471';
-                rt -> data.values as values, 
-                                values.value = rt;
-            };
-        };   
     };
-
-    /* -------------------------- DiagnosticReport ------------------------ */
-    entry.resource as diagnosticReport where "resource is DiagnosticReport and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/DiagnosticReport/nNGM/befund'" then
+    //Fläche positiver Immunzellen / Gesamttumorflächev -> ratio-pos-flaeche component -> 16, 0, id_2182
+    observation -> tgt.data as data then
     {
-        //Befunddatum -> 0, 0, id_1653
-        diagnosticReport -> tgt.data as data then
+        observation.component as component then
         {
-            diagnosticReport.issued as issued then
-            {   
-                diagnosticReport -> data.blockindex  = 0;
-                diagnosticReport -> data.groupindex  = 0;
-                diagnosticReport -> data.itemid      = 'id_1653';
-                issued -> data.values as values, 
-                                        values.value = issued;
-            };
-        };                
-        //Befundnummer -> 0, 0, id_1654
-        diagnosticReport -> tgt.data as data then
-        {
-            diagnosticReport.identifier as identifier,
-                identifier.system as system where "system = 'http://uk-koeln.de/NamingSystem/nNGM/befundnummer'" then
-            {   
-                diagnosticReport -> data.blockindex  = 0;
-                diagnosticReport -> data.groupindex  = 0;
-                diagnosticReport -> data.itemid      = 'id_1654';
-                identifier.value as value-> data.values as values, 
-                                        values.value = value;
-            };
-        };                
-    };
-    /* ---------------------- ObservationHistologie ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'C18000' and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/nngm/histologie'" then
-    {
-        /* -------------------------------- HISTOLOGIE ---------------------------------- */
-        //Klassifikation -> klassifikation component -> 1, 0,  id_1658
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
+            component.valueQuantity as quantity where "code.coding.code = 'tcell-surface-ratio'" then
             {
-                component.code where "code.coding.code = 'C25161'" then
-                {
-                    component.valueCodeableConcept as valueCodeableConcept,
-                    valueCodeableConcept.coding as coding, coding.code as code then 
-                    {
-                        observation -> data.blockindex  = 1;
-                        observation -> data.groupindex  = 0;
-                        observation -> data.itemid      = 'id_1658';
-                        code -> data.values as values, 
-                                            values.value = code;
-                    };
-                };
-            };
-            //Lokalisation -> 1, 0, id_2469
-            observation -> tgt.data as data then
-            {
-                observation.bodySite as bodySite where "$this.bodySite.coding.system = 'urn:oid:2.16.840.1.113883.6.43.1'", 
-                bodySite.coding as coding then
-                {   
-                    observation -> data.blockindex = 1;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2469';
-                    bodySite    -> data.values as values, 
-                                      values.value = evaluate(bodySite, 'coding.code + \'\\t\' + coding.display');
-                };
-            };
-        };
-        //Grading -> 1, 0, id_2403
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as cc, cc.coding as coding then
-            {   
-                observation -> data.blockindex = 1;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2403';
-                coding.code as code -> data.values as values, 
-                                    values.value = code;
-            };
-        };
-    };
-    /*---------------------------------------------------------------------
-                                Immunhistochemie (IHC)                         
-    ----------------------------------------------------------------------- */
-    /* ---------------------- Observation BRAF IHC ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'BRAF'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 4, 0, braf_ihc_group
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 4;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'braf_ihc_group';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 4, 0, braf_ihc_phaenotype
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 4;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'braf_ihc_phaenotype';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                        value   -> data.values as values, 
-                                    values.unit    = 'predef', 
-                                    values.value   = 'Expresssion';
-                };
-            };
-        };
-        //Ergebnis -> 4, 0, braf_ihc_result
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 4;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'braf_ihc_result';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 4;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'braf_ihc_result';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 4;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'braf_ihc_result';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* ---------------------- Observation CK7 IHC ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'CK7'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 5, 0, id_2037
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 5;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2037';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 5, 0, id_2038
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 5;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2038';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                        value   -> data.values as values, 
-                                    values.unit    = 'predef', 
-                                    values.value   = 'Expresssion';
-                };
-            };
-        };
-        //Ergebnis -> 5, 0, id_2045
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 5;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2045';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 5;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2045';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 5;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2045';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* --------------------- Observation MIB1 IHC ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'MIB1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 7, 0, id_2055
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation->data.blockindex = 7;
+                observation->data.blockindex = 16;
                 observation->data.groupindex = 0;
-                observation->data.itemid     = 'id_2055';
-                period as dateOfAssessment-> data.values as values, 
-                                values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 7, 0, id_2056
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2056').exists().not()" then
-                {
-                    vcc.coding as coding where "coding.code = 'C80488'" then
-                    {
-                        observation->data.blockindex = 7;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2056';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                    };
-
-                    vcc.coding as coding where "coding.code = 'C28510'" then
-                    {
-                        observation->data.blockindex = 7;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2056';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                    };
-
-                    vcc.coding as coding where "coding.code = 'C25418'" then
-                    {
-                        observation->data.blockindex = 7;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2056';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                    };
-                };
-            };
-        };
-
-        //Ergebnis -> 7, 0, id_2063
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 7;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2063';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 7;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2063';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 7;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2063';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
+                observation->data.itemid     = 'id_2182';
+                quantity.value as value ->data.values as values, 
+                                values.unit  = 'percent', 
+                                values.value = value;
             };
         };
     };
-    /* ------------------ Observation Napsin A IHC ----------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'Napsin A'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
+}
+
+/* --------------------- Observation ROS1 IHC -------------------------- */
+group TransformVBObservationROS1CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date of Assessment -> 17, 0,id_2211
+    //Phaenotyp -> 17, 0, id_2212
+    //these two items shown before were mapped in the following group
+    observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
+    
+    //Ergebnis -> 17, 0, id_2219
+    observation->tgt.data as data then
     {
-        //Date Of Assesment -> 14, 0, id_2064
-        observation-> tgt.data as data then
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
         {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex   = 14;
-                observation -> data.groupindex   = 0;
-                observation -> data.itemid       = 'id_2064';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 14, 0, id_2065
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                    component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2065').exists().not()" then
-                    {
-                        vcc.coding as coding where "coding.code = 'C80488'" then
-                        {
-                            observation->data.blockindex = 14;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2065';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                        };
-
-                        vcc.coding as coding where "coding.code = 'C28510'" then
-                        {
-                            observation->data.blockindex = 14;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2065';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                        };
-
-                        vcc.coding as coding where "coding.code = 'C25418'" then
-                        {
-                            observation->data.blockindex = 14;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2065';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                        };
-                    };           
-            };
-        };
-        //Ergebnis -> 14, 0, id_2072
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 14;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2072';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 14;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2072';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 14;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2072';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
+            observation->data.blockindex = 17;
+            observation->data.groupindex = 0;
+            observation->data.itemid = 'id_2219';
+            code->data.values as values, values.value = code;
         };
     };
-    /* ---------------------- Observation P40 IHC ------------------------ */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'P40'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 15, 0, id_2073
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex   = 15;
-                observation -> data.groupindex   = 0;
-                observation -> data.itemid       = 'id_2073';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 15, 0, id_2074
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2074').exists().not()" then
-                {
-                    vcc.coding as coding where "coding.code = 'C80488'" then
-                    {
-                        observation->data.blockindex = 15;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2074';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                    };
+}
 
-                    vcc.coding as coding where "coding.code = 'C28510'" then
-                    {
-                        observation->data.blockindex = 15;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2074';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                    };
 
-                    vcc.coding as coding where "coding.code = 'C25418'" then
-                    {
-                        observation->data.blockindex = 15;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2074';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                    };
-                };
-            };
-        };
-        //Ergebnis -> 15, 0, id_2079
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 15;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2079';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
 
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 15;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2079';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
 
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 15;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2079';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* ----------------- Observation Synaptophysin IHC -------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'Synaptophysin'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 18, 0, id_2080
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 18;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2080';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 18, 0, id_2081
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 18;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2081';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                        value   -> data.values as values, 
-                                    values.unit    = 'predef', 
-                                    values.value   = 'Expresssion';
-                };
-            };
-        };
-        //Ergebnis -> 18, 0, id_2088
-        // TODO: Check merge history if this is correct. id_2081 is set here as well
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation.component as component then
-                {
-                    component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2081').exists().not()" then
-                    {
-                        vcc.coding as coding where "coding.code = 'C80488'" then
-                        {
-                            observation->data.blockindex = 18;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2081';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                        };
 
-                        vcc.coding as coding where "coding.code = 'C28510'" then
-                        {
-                            observation->data.blockindex = 18;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2081';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                        };
 
-                        vcc.coding as coding where "coding.code = 'C25418'" then
-                        {
-                            observation->data.blockindex = 18;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2081';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                        };
-                    };
-                };
-            };
 
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 18;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2088';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
 
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 18;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2088';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* --------------------- Observation TTF1 IHC ------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'TTF1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 19, 0, id_2089
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex   = 19;
-                observation -> data.groupindex   = 0;
-                observation -> data.itemid       = 'id_2089';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 19, 0, id_2090
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2090').exists().not()" then
-                {
-                    vcc.coding as coding where "coding.code = 'C80488'" then
-                    {
-                        observation->data.blockindex = 19;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2090';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                    };
 
-                    vcc.coding as coding where "coding.code = 'C28510'" then
-                    {
-                        observation->data.blockindex = 19;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2090';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                    };
-
-                    vcc.coding as coding where "coding.code = 'C25418'" then
-                    {
-                        observation->data.blockindex = 19;
-                        observation->data.groupindex = 0;
-                        observation->data.itemid = 'id_2090';
-                        coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                    };
-                };
-            };
-        };
-        //Ergebnis -> 19, 0, id_2097
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 19;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2097';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 19;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2097';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 19;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2097';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* --------------------- Observation ALK IHC -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ALK'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date of Assessment -> 3, 0,id_2098
-        //Phaenotyp -> 3, 0, id_2099 
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationALKDatePhanotypVorbefund(observation, tgt);
-
-        /* ---------------------------- IHC ---------------------------------- */
-        
-        //Ergebnis -> 3, 0, id_2106
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2106';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-                observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA11884-6'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2106';
-                        code -> data.values as values, 
-                                values.value   = 'fraglich';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2106';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 3;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2106';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
-    /* --------------------- Observation MET IHC -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'MET'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date of Assessment -> 6, 0,id_2132
-        //Phaenotyp -> 6, 0, id_2133
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationMETDatePhanotypVorbefund(observation, tgt);
-
-        //Ergebnis -> 6, 0, id_2139
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2139';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-                observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA11884-6'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2139';
-                        code -> data.values as values, 
-                                values.value   = 'fraglich';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2139';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 6;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2139';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Klassifikation -> Klassifikation component -> 6, 0, id_2140
-        observation -> tgt.data as data then
-        {
-            observation.component as component,
-            component.code where "code.coding.code = 'C25161'" then
-            {
-                component.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then 
-                {
-                    observation -> data.blockindex = 6;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2140';
-                        code -> data.values as values, values.value = code;
-                };
-            };
-        };
-        //Expression high-level -> expression-high-level component -> 6, 0, id_2141
-        // TODO: Check merge history if this is correct. id_2173 is set here as well
-        observation -> tgt.data as data then
-        {
-            observation.component as component,
-            component.code where "code.coding.code = 'C129474'" then
-            {
-                    component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2173').exists().not()" then
-                    {
-                        vcc.coding as coding where "coding.code = 'C80488'" then
-                        {
-                            observation->data.blockindex = 16;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2173';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                        };
-
-                        vcc.coding as coding where "coding.code = 'C28510'" then
-                        {
-                            observation->data.blockindex = 16;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2173';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                        };
-
-                        vcc.coding as coding where "coding.code = 'C25418'" then
-                        {
-                            observation->data.blockindex = 16;
-                            observation->data.groupindex = 0;
-                            observation->data.itemid = 'id_2173';
-                            coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                        };
-                    };
-
-                component.valueBoolean as valueBoolean where "value = false" then 
-                {
-                    observation  -> data.blockindex = 6;
-                    observation  -> data.groupindex = 0;
-                    observation  -> data.itemid     = 'id_2141';
-                    valueBoolean -> data.values as values, values.value = 'no';
-                };
-            };
-        };
-    };
-    /* --------------------- Observation PD-L1 IHC ------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'PD-L1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date Of Assesment -> 16, 0, id_2172
-        observation-> tgt.data as data then
-        {
-            observation.effectiveDateTime as period then
-            {
-                observation -> data.blockindex = 16;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2172';
-                period as dateOfAssessment-> data.values as values, 
-                                    values.value = dateOfAssessment;
-            };
-        };
-        //Phänotyp: phanotyp component-> 16, 0, id_2173
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = 'C16977'" then
-            {
-                component.valueString as value  then
-                {
-                    observation -> data.blockindex = 16;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_2173';
-                        value   -> data.values as values,
-                                    values.value   = value;
-                        value   -> data.values as values, 
-                                    values.unit    = 'predef', 
-                                    values.value   = 'Expresssion';
-                };
-            };
-        };
-        //Ergebnis -> 16, 0, id_2180
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 16;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2180';
-                        code -> data.values as values, 
-                                values.value   = 'auswertbar';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 16;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2180';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-        //Menge der Tumorzellen (% positive Tumorzellen TPS) -> menge-tumorzellen component -> 16, 0, id_2181
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C127771'" then
-                {
-                    observation->data.blockindex = 16;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2181';
-                    quantity.value as value ->data.values as values, 
-                                    values.unit  = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-        //Fläche positiver Immunzellen / Gesamttumorflächev -> ratio-pos-flaeche component -> 16, 0, id_2182
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'tcell-surface-ratio'" then
-                {
-                    observation->data.blockindex = 16;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid     = 'id_2182';
-                    quantity.value as value ->data.values as values, 
-                                    values.unit  = 'percent', 
-                                    values.value = value;
-                };
-            };
-        };
-    };
-    /* --------------------- Observation ROS1 IHC -------------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.code = 'ROS1'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ihc'" then
-    {
-        //Date of Assessment -> 17, 0,id_2211
-        //Phaenotyp -> 17, 0, id_2212
-        //these two items shown before were mapped in the following group
-        observation then TransformationObservationROS1DatePhanotypVorbefund(observation, tgt);
-        
-        //Ergebnis -> 17, 0, id_2219
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6576-8'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2219';
-                        code -> data.values as values, 
-                                values.value   = 'positiv';
-            };
-
-                observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA11884-6'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2219';
-                        code -> data.values as values, 
-                                values.value   = 'fraglich';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA6577-6'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2219';
-                        code -> data.values as values, 
-                                values.value   = 'negativ';
-            };
-
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code where "code = 'LA18198-4'" then
-            {
-                observation -> data.blockindex = 17;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_2219';
-                        code -> data.values as values,
-                                values.value   = 'nicht auswertbar';
-            };
-        };
-    };
+group Rest(source entry: BackboneElement, target tgt: BackboneElement, target index: RepeatIndex)
+{
+ 
     /*---------------------------------------------------------------------
                     Chromogenic in-situ-Hybridisierung (CISH)               
     ------------------------------------------------------------------------ */
@@ -3416,6 +3027,7 @@ group TransformVorbefundCDS(source entry: BackboneElement, target tgt: BackboneE
         };
     };
 }
+
 /*------------------------------------------------------------------------------
                              HELPERS                                   
 ------------------------------------------------------------------------------*/
@@ -3429,49 +3041,28 @@ group TransformationObservationALKDatePhanotypVorbefund(source observation:Obser
             observation -> data.blockindex   = 3;
             observation -> data.groupindex   = 0;
             observation -> data.itemid       = 'id_2098';
-            edt-> data.values as values, 
-                        values.value = edt;
+            edt-> data.values as values, values.value = edt;
         };
     };
     
     //Phänotyp: phanotyp component-> 3, 0, id_2099
     observation -> tgt.data as data then
     {
-        observation.component as component, 
-        component.code where "code.coding.code = 'C16977'" then
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
         {
             component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2099').exists().not()" then
             {
-                vcc.coding as coding where "coding.code = 'C80488'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2099';
-                    coding->data.values as values, values.value = 'Expression';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                };
-
-                vcc.coding as coding where "coding.code = 'C28510'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2099';
-                    coding->data.values as values, values.value = 'Fusion';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                };
-
-                vcc.coding as coding where "coding.code = 'C25418'" then
-                {
-                    observation->data.blockindex = 3;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2099';
-                    coding->data.values as values, values.value = 'Amplifikation';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                };
+                observation -> data.blockindex = 3;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2099';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
             };
         };
     };
 }
+
 group TransformationObservationMETDatePhanotypVorbefund(source observation:Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 6, 0, id_2132
@@ -3482,100 +3073,60 @@ group TransformationObservationMETDatePhanotypVorbefund(source observation:Obser
             observation -> data.blockindex = 6;
             observation -> data.groupindex = 0;
             observation -> data.itemid     = 'id_2132';
-            edt-> data.values as values, 
-                      values.value = edt;
+            edt-> data.values as values, values.value = edt;
         };
     };
+
     //Phänotyp: phanotyp component-> 6, 0, id_2133
     observation -> tgt.data as data then
     {
-        observation.component as component, 
-        component.code where "code.coding.code = 'C16977'" then
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
         {
             component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2133').exists().not()" then
             {
-                vcc.coding as coding where "coding.code = 'C80488'" then
-                {
-                    observation->data.blockindex = 6;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2133';
-                    coding->data.values as values, values.value = 'Expression';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                };
-
-                vcc.coding as coding where "coding.code = 'C28510'" then
-                {
-                    observation->data.blockindex = 6;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2133';
-                    coding->data.values as values, values.value = 'Fusion';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                };
-
-                vcc.coding as coding where "coding.code = 'C25418'" then
-                {
-                    observation->data.blockindex = 6;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2133';
-                    coding->data.values as values, values.value = 'Amplifikation';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                };
+                observation -> data.blockindex = 6;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2133';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
             };
         };
     };
 }
+
 group TransformationObservationROS1DatePhanotypVorbefund(source observation:Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 17, 0, id_2211
     observation-> tgt.data as data then
     {
-        observation.effectiveDateTime as period, 
-        period as dateOfAssessment where "%tgt.data.where(itemid = 'id_2211').exists().not()" then
+        observation.effectiveDateTime as edt where "code.coding.code = 'ROS1' and %tgt.data.where(itemid = 'id_2211').exists().not()" then
         {
             observation -> data.blockindex = 17;
             observation -> data.groupindex = 0;
             observation -> data.itemid     = 'id_2211';
-            dateOfAssessment-> data.values as values, 
-                      values.value = dateOfAssessment;
+            edt-> data.values as values, values.value = edt;
         };
     };
+
     //Phänotyp: phanotyp component-> 17, 0, id_2212
     observation -> tgt.data as data then
     {
-        observation.component as component then
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
         {
             component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2212').exists().not()" then
             {
-                vcc.coding as coding where "coding.code = 'C80488'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2212';
-                    coding->data.values as values, values.value = 'Expression';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                };
-
-                vcc.coding as coding where "coding.code = 'C28510'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2212';
-                    coding->data.values as values, values.value = 'Fusion';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                };
-
-                vcc.coding as coding where "coding.code = 'C25418'" then
-                {
-                    observation->data.blockindex = 17;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2212';
-                    coding->data.values as values, values.value = 'Amplifikation';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                };
+                observation -> data.blockindex = 17;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2212';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
             };
         };
     };
 }
+
 group TransformationObservationRETDatePhanotypVorbefund(source observation:Observation, target tgt: BackboneElement)
 {
      //Date Of Assesment -> 20, 0, id_2183
@@ -3593,41 +3144,21 @@ group TransformationObservationRETDatePhanotypVorbefund(source observation:Obser
     //Phänotyp: phanotyp component-> 20, 0, id_2184
     observation -> tgt.data as data then
     {
-        observation.component as component, 
-        component.code where "code.coding.code = 'C16977'" then
+        observation.component as component, component.code where "code.coding.code = 'C16977'" then
         {
             component.valueCodeableConcept as vcc where "%tgt.data.where(itemid = 'id_2184').exists().not()" then
             {
-                vcc.coding as coding where "coding.code = 'C80488'" then
-                {
-                    observation->data.blockindex = 20;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2184';
-                    coding->data.values as values, values.value = 'Expression';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Expression';
-                };
-
-                vcc.coding as coding where "coding.code = 'C28510'" then
-                {
-                    observation->data.blockindex = 20;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2184';
-                    coding->data.values as values, values.value = 'Fusion';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Fusion';
-                };
-
-                vcc.coding as coding where "coding.code = 'C25418'" then
-                {
-                    observation->data.blockindex = 20;
-                    observation->data.groupindex = 0;
-                    observation->data.itemid = 'id_2184';
-                    coding->data.values as values, values.value = 'Amplifikation';
-                    coding->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
-                };
+                observation -> data.blockindex = 20;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid     = 'id_2184';
+                vcc.coding as coding where "coding.code = 'C80488'"->data.values as values, values.unit = 'predef', values.value = 'Expression';
+                vcc.coding as coding where "coding.code = 'C28510'"->data.values as values, values.unit = 'predef', values.value = 'Fusion';
+                vcc.coding as coding where "coding.code = 'C25418'"->data.values as values, values.unit = 'predef', values.value = 'Amplifikation';
             };
         };
     };
 }
+
 group TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(source observation:Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 23, 0, ft_grp_egfr_19-21

--- a/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
+++ b/CDS Maps/Individual Maps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Vorbefund.map
@@ -1,6 +1,12 @@
 /// version = 0.1
 /// title = "nNGM_Mapping_VorbefundCTS"
 
+/* 
+    TODO
+    - "Sonstige Fusion NGS" Observation: if there is only 1 "Fusionspartner" given, it gets mapped to the "Erster Fusionspartner" (id_2255) even if it was entered 
+        in the "Zweiter Fusionspartner" field. This behaviour is because both components for the Fusionspartner are using the same code (48018-6)
+*/
+
 map "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundCDS" = nNGM_Mapping_VorbefundCDS
 
 uses "http://hl7.org/fhir/StructureDefinition/Bundle" as source
@@ -34,8 +40,16 @@ group TransformVorbefundCDS(source entry: BackboneElement, target tgt: BackboneE
         then TransformVBObservationFSCDS(observation, tgt, index);
 
     // Fast Track 
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'"
+        then TransformVBObservationFTCDS(observation, tgt);
 
-    // NGS Lung Panel - evaluates index.sectionIndex as repeatindex
+    // NGS Panel - evaluates index.sectionIndex as repeatindex
+    entry.resource as observation where "resource is Observation and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-panel'" 
+        then TransformVBObservationLPCDS(observation, tgt, index);
+
+    // NGS Panel Device  
+    entry.resource as device where "resource is Device and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device/nNGM/ngs-panel'" 
+        then TransformVBDeviceLPCDS(device, tgt);
 }
 
 /* ------------------------------ Specimen ---------------------------- */
@@ -2013,492 +2027,465 @@ group TransformVBFSObservationSonstigeCDS(source observation: Observation, targe
     };
 }
 
-
-
-group Rest(source entry: BackboneElement, target tgt: BackboneElement, target index: RepeatIndex)
+/*------------------------------------------------------------------------------
+                            Fast Track                                  
+------------------------------------------------------------------------------*/
+group TransformVBObservationFTCDS(source observation: Observation, target tgt: BackboneElement)
 {
+    observation where "code.coding.code = 'BRAF Exon 15'" then TransformVBFTObservationBRAFExon15CDS(observation, tgt);
+    observation where "code.coding.code = 'EGFR Exon 19'" then TransformVBFTObservationEGFRExon19CDS(observation, tgt);
+    observation where "code.coding.code = 'EGFR Exon 20'" then TransformVBFTObservationEGFRExon20CDS(observation, tgt);
+    observation where "code.coding.code = 'EGFR Exon 21'" then TransformVBFTObservationEGFRExon21CDS(observation, tgt);
+    observation where "code.coding.code = 'KRAS Exon 2'" then TransformVBFTObservationKRASExon2CDS(observation, tgt);
+}
 
-    /*------------------------------------------------------------------------------
-                                Fast Track                                  
-    ------------------------------------------------------------------------------*/
-    /* ------------ Observation BRAF Exon 15 Fast Track -------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.display = 'BRAF Exon 15 Mutation'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'" then
+/* ------------ Observation BRAF Exon 15 Fast Track -------------------- */
+group TransformVBFTObservationBRAFExon15CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 22, 0, id_1945
+    observation-> tgt.data as data then
     {
-        //Date Of Assesment -> 22, 0, id_1945
-        observation-> tgt.data as data then
+        observation.effectiveDateTime as effectiveDateTime then
         {
-            observation.effectiveDateTime as effectiveDateTime then
+            observation -> data.blockindex = 22;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1945';
+            effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
+        };
+    };
+    //Ergebnis -> 22, 0, id_1946
+    
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation -> data.blockindex = 22;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1946';
+                    code -> data.values as values, values.value = code;
+        };
+    };
+    //Change DNA -> dna-chg component -> 22, 0, id_1947
+    observation -> tgt.data as data then
+    {
+        observation.component as component, 
+        component.code where "code.coding.code = '48004-6'" then
+        {
+            component.valueString as valueString then
             {
                 observation -> data.blockindex = 22;
                 observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1945';
-                effectiveDateTime -> data.values as values, 
-                                    values.value = effectiveDateTime;
-            };
-        };
-        //Ergebnis -> 22, 0, id_1946
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then
-            {
-                observation -> data.blockindex = 22;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1946';
-                        code -> data.values as values, 
-                                values.value   = code;
-            };
-        };
-        //Change DNA -> dna-chg component -> 22, 0, id_1947
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48004-6'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex = 22;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_1947';
-                    valueString -> data.values as values,
-                                    values.value   = valueString;
-                };
-            };
-        };
-        //Change Protein -> amino-acid-chg component -> 22, 0, id_1948
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48005-3'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex  = 22;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.itemid      = 'id_1948';
-                    valueString -> data.values as values,
-                                    values.value    = valueString;
-                };
+                observation -> data.itemid     = 'id_1947';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /* ------------ Observation BRAF Exon 19 Fast Track -------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.display = 'EGFR Exon 19 Mutation'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'" then
+    //Change Protein -> amino-acid-chg component -> 22, 0, id_1948
+    observation -> tgt.data as data then
     {
-        //Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
-        // Assay -> assay component -> 23, 0, id_2608
-        // Hersteller -> hersteller -> 23, 0, id_2609
-        //these three items shown before were mapped in the following group
-        observation then TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(observation, tgt);
-
-        //Ergebnis -> 23, 0, id_1950
-        observation -> tgt.data as data then
+        observation.component as component, 
+        component.code where "code.coding.code = '48005-3'" then
         {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 22;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1948';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+}
+
+/* ------------ Observation BRAF Exon 19 Fast Track -------------------- */
+group TransformVBFTObservationEGFRExon19CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    // Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
+    // Assay -> assay component -> 23, 0, id_2608
+    // Hersteller -> hersteller -> 23, 0, id_2609
+    //these three items shown before were mapped in the following group
+    observation then TransformObservationVBFTDateAssayHerstellerEGFREXO1921(observation, tgt);
+
+    //Ergebnis -> 23, 0, id_1950
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation -> data.blockindex = 23;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1950';
+                    code -> data.values as values, values.value = code;
+        };
+    };
+    //Change DNA -> dna-chg component -> 23, 0, id_1951
+    observation -> tgt.data as data then
+    {
+        observation.component as component, 
+        component.code where "code.coding.code = '48004-6'" then
+        {
+            component.valueString as valueString then
             {
                 observation -> data.blockindex = 23;
                 observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1950';
-                        code -> data.values as values, 
-                                values.value   = code;
-            };
-        };
-        //Change DNA -> dna-chg component -> 23, 0, id_1951
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48004-6'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex = 23;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_1951';
-                    valueString -> data.values as values,
-                                    values.value   = valueString;
-                };
-            };
-        };
-        //Change Protein -> amino-acid-chg component -> 23, 0, id_1952
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48005-3'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex  = 23;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.itemid      = 'id_1952';
-                    valueString -> data.values as values,
-                                    values.value    = valueString;
-                };
+                observation -> data.itemid     = 'id_1951';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /* ------------ Observation BRAF Exon 20 Fast Track -------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.display = 'EGFR Exon 20 Mutation'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'" then
+    //Change Protein -> amino-acid-chg component -> 23, 0, id_1952
+    observation -> tgt.data as data then
     {
-        //Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
-        // Assay -> assay component -> 23, 0, id_2608
-        // Hersteller -> hersteller -> 23, 0, id_2609
-        //these three items shown before were mapped in the following group
-        observation then TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(observation, tgt);
-
-        //Ergebnis -> 23, 0, id_1954
-        observation -> tgt.data as data then
+        observation.component as component, 
+        component.code where "code.coding.code = '48005-3'" then
         {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 23;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1952';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+}
+
+/* ------------ Observation BRAF Exon 20 Fast Track -------------------- */
+group TransformVBFTObservationEGFRExon20CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    // Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
+    // Assay -> assay component -> 23, 0, id_2608
+    // Hersteller -> hersteller -> 23, 0, id_2609
+    //these three items shown before were mapped in the following group
+    observation then TransformObservationVBFTDateAssayHerstellerEGFREXO1921(observation, tgt);
+
+    //Ergebnis -> 23, 0, id_1954
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation -> data.blockindex = 23;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1954';
+            code -> data.values as values, values.value = code;
+        };
+    };
+    //Change DNA -> dna-chg component -> 23, 0, id_1955
+    observation -> tgt.data as data then
+    {
+        observation.component as component, 
+        component.code where "code.coding.code = '48004-6'" then
+        {
+            component.valueString as valueString then
             {
                 observation -> data.blockindex = 23;
                 observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1954';
-                        code -> data.values as values, 
-                                values.value   = code;
-            };
-        };
-        //Change DNA -> dna-chg component -> 23, 0, id_1955
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48004-6'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex = 23;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_1955';
-                    valueString -> data.values as values,
-                                    values.value   = valueString;
-                };
-            };
-        };
-        //Change Protein -> amino-acid-chg component -> 23, 0, id_1956
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48005-3'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex  = 23;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.itemid      = 'id_1956';
-                    valueString -> data.values as values,
-                                    values.value    = valueString;
-                };
+                observation -> data.itemid     = 'id_1955';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /* ------------ Observation BRAF Exon 21 Fast Track -------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.display = 'EGFR Exon 21 Mutation'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'" then
+    //Change Protein -> amino-acid-chg component -> 23, 0, id_1956
+    observation -> tgt.data as data then
     {
-        //Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
-        // Assay -> assay component -> 23, 0, id_2608
-        // Hersteller -> hersteller -> 23, 0, id_2609
-        //these three items shown before were mapped in the following group
-        observation then TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(observation, tgt);
-
-        //Ergebnis -> 23, 0, id_1958
-        observation -> tgt.data as data then
+        observation.component as component, 
+        component.code where "code.coding.code = '48005-3'" then
         {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 23;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1956';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+}
+
+/* ------------ Observation BRAF Exon 21 Fast Track -------------------- */
+group TransformVBFTObservationEGFRExon21CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    // Date of Assessment  -> 23, 0, ft_grp_egfr_19-21
+    // Assay -> assay component -> 23, 0, id_2608
+    // Hersteller -> hersteller -> 23, 0, id_2609
+    //these three items shown before were mapped in the following group
+    observation then TransformObservationVBFTDateAssayHerstellerEGFREXO1921(observation, tgt);
+
+    //Ergebnis -> 23, 0, id_1958
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation -> data.blockindex = 23;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1958';
+            code -> data.values as values, values.value = code;
+        };
+    };
+    //Change DNA -> dna-chg component -> 23, 0, id_1959
+    observation -> tgt.data as data then
+    {
+        observation.component as component, 
+        component.code where "code.coding.code = '48004-6'" then
+        {
+            component.valueString as valueString then
             {
                 observation -> data.blockindex = 23;
                 observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1958';
-                        code -> data.values as values, 
-                                values.value   = code;
-            };
-        };
-        //Change DNA -> dna-chg component -> 23, 0, id_1959
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48004-6'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex = 23;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_1959';
-                    valueString -> data.values as values,
-                                    values.value   = valueString;
-                };
-            };
-        };
-        //Change Protein -> amino-acid-chg component -> 23, 0, id_1960
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48005-3'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex  = 23;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.itemid      = 'id_1960';
-                    valueString -> data.values as values,
-                                    values.value    = valueString;
-                };
+                observation -> data.itemid     = 'id_1959';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /* -------------- Observation KRAS Exon Fast Track --------------------- */
-    entry.resource as observation where "resource is Observation and resource.code.coding.display = 'KRAS Exon 2 Mutation'
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/fasttrack'" then
+    //Change Protein -> amino-acid-chg component -> 23, 0, id_1960
+    observation -> tgt.data as data then
     {
-        //Date Of Assesment -> 24, 0, id_1961
-        observation-> tgt.data as data then
+        observation.component as component, 
+        component.code where "code.coding.code = '48005-3'" then
         {
-            observation.effectiveDateTime as effectiveDateTime then
+            component.valueString as valueString then
+            {
+                observation -> data.blockindex  = 23;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1960';
+                valueString -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+}
+
+/* ------------ Observation KRAS Exon 2 Fast Track -------------------- */
+group TransformVBFTObservationKRASExon2CDS(source observation: Observation, target tgt: BackboneElement)
+{
+    //Date Of Assesment -> 24, 0, id_1961
+    observation-> tgt.data as data then
+    {
+        observation.effectiveDateTime as effectiveDateTime then
+        {
+            observation -> data.blockindex = 24;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1961';
+            effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
+        };
+    };
+
+    //Ergebnis -> 24, 0, id_1962
+    observation -> tgt.data as data then
+    {
+        observation.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding,
+            coding.code as code then
+        {
+            observation -> data.blockindex = 24;
+            observation -> data.groupindex = 0;
+            observation -> data.itemid     = 'id_1962';
+            code -> data.values as values, values.value = code;
+        };
+    };
+    //Change DNA -> dna-chg component -> 24, 0, id_1963
+    observation -> tgt.data as data then
+    {
+        observation.component as component, 
+        component.code where "code.coding.code = '48004-6'" then
+        {
+            component.valueString as valueString then
             {
                 observation -> data.blockindex = 24;
                 observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1961';
-                effectiveDateTime -> data.values as values, 
-                                    values.value = effectiveDateTime;
-            };
-        };
-        //Ergebnis -> 24, 0, id_1962
-        observation -> tgt.data as data then
-        {
-            observation.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding,
-                coding.code as code then
-            {
-                observation -> data.blockindex = 24;
-                observation -> data.groupindex = 0;
-                observation -> data.itemid     = 'id_1962';
-                        code -> data.values as values, 
-                                values.value   = code;
-            };
-        };
-        //Change DNA -> dna-chg component -> 24, 0, id_1963
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48004-6'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex = 24;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid     = 'id_1963';
-                    valueString -> data.values as values,
-                                    values.value   = valueString;
-                };
-            };
-        };
-        //Change Protein -> amino-acid-chg component -> 24, 0, id_1964
-        observation -> tgt.data as data then
-        {
-            observation.component as component, 
-            component.code where "code.coding.code = '48005-3'" then
-            {
-                component.valueString as valueString then
-                {
-                    observation -> data.blockindex  = 24;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.itemid      = 'id_1964';
-                    valueString -> data.values as values,
-                                    values.value    = valueString;
-                };
+                observation -> data.itemid     = 'id_1963';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /*------------------------------------------------------------------------------
-                                Fusion NGS                                  
-    ------------------------------------------------------------------------------*/
-    /* --------------------- Device NGSPanel Fusion NGS -------------------- */
-    entry.resource as device where "resource is Device and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Device'" then
+    //Change Protein -> amino-acid-chg component -> 24, 0, id_1964
+    observation -> tgt.data as data then
     {
-        //NGS Lung Panel Version -> 25, 0, id_1260
-        device -> tgt.data as data then
+        observation.component as component, 
+        component.code where "code.coding.code = '48005-3'" then
         {
-            device.version as version, 
-            version.value as value then
+            component.valueString as valueString then
             {
-                device -> data.blockindex = 25;
-                device -> data.groupindex = 0;
-                device -> data.itemid     = 'id_1260';
-                value  -> data.values as values, 
-                                values.value = value;
+                observation -> data.blockindex  = 24;
+                observation -> data.groupindex  = 0;
+                observation -> data.itemid      = 'id_1964';
+                valueString -> data.values as values, values.value = valueString;
             };
         };
     };
-    /* ----------------- Observation NGSPanel Fusion NGS ------------------- */
-    entry.resource as observation where "resource is Observation 
-                                        and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-panel'" then
+}
+
+/*------------------------------------------------------------------------------
+                            NGS Panel                                  
+------------------------------------------------------------------------------*/
+/* ----------------------- Observation NGS Panel ---------------------- */
+group TransformVBObservationLPCDS(source observation: Observation, target tgt: BackboneElement, target index: RepeatIndex)
+{
+    //Date Of Assesment -> 26, 0, 0, id_1160
+    observation-> tgt.data as data then
     {
-        //Date Of Assesment -> 26, 0, 0, id_1160
-        observation-> tgt.data as data then
+        observation.effectiveDateTime as effectiveDateTime then
         {
-            observation.effectiveDateTime as effectiveDateTime then
+            observation -> data.blockindex  = 26;
+            observation -> data.groupindex  = 0;
+            observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+            observation -> data.itemid      = 'id_1160';
+            effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
+        };
+    };
+    //Gen -> gene-studied -> 26, 0, id_1159
+    observation -> tgt.data as data then
+    {
+        observation.component as component, component.code where "code.coding.code = '48018-6'" then
+        {
+            component.valueCodeableConcept as valueCodeableConcept,
+            valueCodeableConcept.coding as coding, coding.code as code  then
             {
                 observation -> data.blockindex  = 26;
                 observation -> data.groupindex  = 0;
                 observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                observation -> data.itemid      = 'id_1160';
-                effectiveDateTime -> data.values as values, 
-                                    values.value = effectiveDateTime;
+                observation -> data.itemid      = 'id_1159';
+                    code   -> data.values as values, values.value = code;
             };
         };
-        //Gen -> gene-studied -> 26, 0, id_1159
-        observation -> tgt.data as data then
+    };
+    //Exon -> exon -> 26, 0, 0, id_35
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
         {
-            observation.component as component, 
-            component.code where "code.coding.code = '48018-6'" then
+            component.valueString as valueString where "code.coding.code = 'C13231'" then
             {
-                component.valueCodeableConcept as valueCodeableConcept,
-                valueCodeableConcept.coding as coding, coding.code as code  then
-                {
-                    observation -> data.blockindex  = 26;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation -> data.itemid      = 'id_1159';
-                        code   -> data.values as values,
-                                    values.value    = code;
-                };
+                observation  -> data.blockindex  = 26;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation  -> data.itemid      = 'id_35';
+                valueString  -> data.values as values, values.value = valueString;
             };
         };
-        //Exon -> exon -> 26, 0, 0, id_35
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueString as valueString where "code.coding.code = 'C13231'" then
-                {
-                    observation  -> data.blockindex  = 26;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation  -> data.itemid      = 'id_35';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
-            };
-        };
+    };
 
-        //HGVS c. (Mutation cDNA) -> dna-chg -> 26, 0, 0, id_36
-        observation -> tgt.data as data then
+    //HGVS c. (Mutation cDNA) -> dna-chg -> 26, 0, 0, id_36
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
         {
-            observation.component as component then
+            component.valueString as valueString where "code.coding.code = '48004-6'" then
             {
-                component.valueString as valueString where "code.coding.code = '48004-6'" then
-                {
-                    observation  -> data.blockindex  = 26;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation  -> data.itemid      = 'id_36';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
+                observation  -> data.blockindex  = 26;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation  -> data.itemid      = 'id_36';
+                valueString  -> data.values as values, values.value = valueString;
             };
         };
-        //HGVS p. (Mutation Protein) -> 26, 0, 0, id_37
-        observation -> tgt.data as data then
+    };
+    //HGVS p. (Mutation Protein) -> 26, 0, 0, id_37
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
         {
-            observation.component as component then
+            component.valueString as valueString where "code.coding.code = '48005-3'" then
             {
-                component.valueString as valueString where "code.coding.code = '48005-3'" then
-                {
-                    observation  -> data.blockindex  = 26;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation  -> data.itemid      = 'id_37';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
+                observation  -> data.blockindex  = 26;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation  -> data.itemid      = 'id_37';
+                valueString  -> data.values as values, values.value = valueString;
             };
         };
-        //Allelic fraction -> allelicfraction  -> 26, 0, 0, id_38
-        observation -> tgt.data as data then
+    };
+    //Allelic fraction -> allelicfraction  -> 26, 0, 0, id_38
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
         {
-            observation.component as component then
-            {
-                component.valueQuantity as quantity where "code.coding.code = 'C154665'" then
-                {
-                    observation -> data.blockindex  = 26;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation -> data.itemid      = 'id_38';
-                    quantity.value as value ->data.values as values, 
-                                        values.unit = 'percent', 
-                                        values.value = value;
-                };
-            };
-        };
-        //Referenztranskript -> referenztranskript -> 26, 0, 0, ngs_panel_reftranscript
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueString as valueString where "code.coding.code = '51958-7'" then
-                {
-                    observation  -> data.blockindex  = 26;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation  -> data.itemid      = 'ngs_panel_reftranscript';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
-            };
-        };
-        //Coverage -> coverage -> 26, 0, 0, ngs_panel_coverage
-        observation -> tgt.data as data then
-        {
-            observation.component as component then
-            {
-                component.valueString as valueString where "code.coding.code = '82121-5'" then
-                {
-                    observation  -> data.blockindex  = 26;
-                    observation  -> data.groupindex  = 0;
-                    observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation  -> data.itemid      = 'ngs_panel_coverage';
-                    valueString  -> data.values as values,
-                                    values.value     =  valueString;
-                };
-            };
-        };
-        //Biologische/molekulare Bewertung  -> 26, 0, 0, id_47
-        observation -> tgt.data as data then
-        {
-            observation.interpretation as interpretation,
-                interpretation.coding as coding,
-                coding.code as code then
-                {
-                    observation -> data.blockindex  = 26;
-                    observation -> data.groupindex  = 0;
-                    observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                    observation -> data.itemid      = 'id_47';
-                        code -> data.values as values, 
-                                    values.value    = code;
-                };
-        };
-        //Kommentar -> 26, 0, 0, id_48
-        observation -> tgt.data as data then
-        {
-            observation.note as note, 
-            note.text as text then
+            component.valueQuantity as quantity where "code.coding.code = 'C154665'" then
             {
                 observation -> data.blockindex  = 26;
                 observation -> data.groupindex  = 0;
                 observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
-                observation -> data.itemid      = 'id_48';
-                        text -> data.values as values, 
-                                values.value    = text;
+                observation -> data.itemid      = 'id_38';
+                quantity.value as value ->data.values as values, values.unit = 'percent', values.value = value;
             };
+        };
+    };
+    //Referenztranskript -> referenztranskript -> 26, 0, 0, ngs_panel_reftranscript
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueString as valueString where "code.coding.code = '51958-7'" then
+            {
+                observation  -> data.blockindex  = 26;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation  -> data.itemid      = 'ngs_panel_reftranscript';
+                valueString  -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Coverage -> coverage -> 26, 0, 0, ngs_panel_coverage
+    observation -> tgt.data as data then
+    {
+        observation.component as component then
+        {
+            component.valueString as valueString where "code.coding.code = '82121-5'" then
+            {
+                observation  -> data.blockindex  = 26;
+                observation  -> data.groupindex  = 0;
+                observation  -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation  -> data.itemid      = 'ngs_panel_coverage';
+                valueString  -> data.values as values, values.value = valueString;
+            };
+        };
+    };
+    //Biologische/molekulare Bewertung  -> 26, 0, 0, id_47
+    observation -> tgt.data as data then
+    {
+        observation.interpretation as interpretation,
+            interpretation.coding as coding,
+            coding.code as code then
+            {
+                observation -> data.blockindex  = 26;
+                observation -> data.groupindex  = 0;
+                observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+                observation -> data.itemid      = 'id_47';
+                    code -> data.values as values, values.value = code;
+            };
+    };
+    //Kommentar -> 26, 0, 0, id_48
+    observation -> tgt.data as data then
+    {
+        observation.note as note, note.text as text then
+        {
+            observation -> data.blockindex  = 26;
+            observation -> data.groupindex  = 0;
+            observation -> data.repeatindex = evaluate(index, '$this.sectionIndex');
+            observation -> data.itemid      = 'id_48';
+                    text -> data.values as values, values.value = text;
+        };
+    };
+}
+
+/* --------------------- Device NGSPanel Fusion NGS -------------------- */
+group TransformVBDeviceLPCDS(source device: Device, target tgt: BackboneElement)
+{
+    //NGS Lung Panel Version -> 25, 0, id_1260
+    device -> tgt.data as data then
+    {
+        device.version as version, version.value as value then
+        {
+            device -> data.blockindex = 25;
+            device -> data.groupindex = 0;
+            device -> data.itemid     = 'id_1260';
+            value  -> data.values as values, values.value = value;
         };
     };
 }
@@ -2634,7 +2621,7 @@ group TransformationObservationRETDatePhanotypVorbefund(source observation:Obser
     };
 }
 
-group TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(source observation:Observation, target tgt: BackboneElement)
+group TransformObservationVBFTDateAssayHerstellerEGFREXO1921(source observation:Observation, target tgt: BackboneElement)
 {
     //Date Of Assesment -> 23, 0, ft_grp_egfr_19-21
     observation-> tgt.data as data then
@@ -2644,15 +2631,13 @@ group TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(source observa
             observation -> data.blockindex   = 23;
             observation -> data.groupindex   = 0;
             observation -> data.itemid       = 'ft_grp_egfr_19-21';
-            effectiveDateTime -> data.values as values, 
-                        values.value = effectiveDateTime;
+            effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
         };
     };
     //Assay -> assay component -> 23, 0, id_2608
     observation -> tgt.data as data then
     {
-        observation.component as component, 
-        component.code where "code.coding.code = 'C60819'" then
+        observation.component as component, component.code where "code.coding.code = 'C60819'" then
         {
             component.valueCodeableConcept as valueCodeableConcept,
             valueCodeableConcept.coding as coding, 
@@ -2661,8 +2646,7 @@ group TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(source observa
                 observation -> data.blockindex = 23;
                 observation -> data.groupindex = 0;
                 observation -> data.itemid     = 'id_2608';
-                    code -> data.values as values,
-                        values.value   = code;
+                code -> data.values as values, values.value = code;
             };
         };
     };
@@ -2679,8 +2663,7 @@ group TransformObservationFastTrackDateAssayHerstellerEGFREXO1921(source observa
                 observation -> data.blockindex = 23;
                 observation -> data.groupindex = 0;
                 observation -> data.itemid     = 'id_2609';
-                    code -> data.values as values,
-                        values.value   = code;
+                code -> data.values as values, values.value = code;
             };
         };
     };

--- a/CDS Maps/nNGM-CDS-to-FHIR-Master.map
+++ b/CDS Maps/nNGM-CDS-to-FHIR-Master.map
@@ -40,9 +40,9 @@ group MapCDS(source src: CTS_Transport, target tgt: Bundle)
     src -> tgt.id = uuid();
     src -> tgt.type = 'collection';
 
-    // src then MapStammdaten(src, tgt);
+    src then MapStammdaten(src, tgt);
     src then MapAntrag(src, tgt);
-    // src then MapBefund(src, tgt);
+    src then MapBefund(src, tgt);
     // TODO
     // src then MapTherapies(src, tgt);
     src then MapTNM(src, tgt);
@@ -159,11 +159,11 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
 
         /* ------------------------------ Resources ---------------------------- */
 
-        // // Basisangaben (Antrag.basisangaben)
-        // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" then
-        // {
-        //     src then TransformBundleBasisangaben(operations, bundleAntrag, compositionAntrag);
-        // };
+        // Basisangaben (Antrag.basisangaben)
+        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" then
+        {
+            src then TransformBundleBasisangaben(operations, bundleAntrag, compositionAntrag);
+        };
 
         // Biopsie(n) (Antrag.biopsie) (Create one biopsy section per biopsie)
         src then InitFormIndex(src, index); // the formIndex indicates which biopsie (an thus which biopsieSection) should be created
@@ -178,23 +178,23 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
                                                 formularId.value = evaluate(index, '$this.formIndex.toString()');
 
             /* ------------------------------ Resources ---------------------------- */
-            // // Anforderung (Antrag.biopsie.anforderung)
-            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            // {
-            //     src then TransformBundleAnforderung(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            // };
+            // Anforderung (Antrag.biopsie.anforderung)
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            {
+                src then TransformBundleAnforderung(operations, bundleAntrag, compositionAntrag, biopsieSection);
+            };
 
-            // // TNM (Antrag.biopsie.tnm)
-            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            // {
-            //     src then TransformBundleTNM(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            // };
+            // TNM (Antrag.biopsie.tnm)
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            {
+                src then TransformBundleTNM(operations, bundleAntrag, compositionAntrag, biopsieSection);
+            };
 
-            // // Resistenztestung (Antrag.biopsie.resistenztestung)
-            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            // {
-            //     src then TransformBundleResistenztestung(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            // };
+            // Resistenztestung (Antrag.biopsie.resistenztestung)
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            {
+                src then TransformBundleResistenztestung(operations, bundleAntrag, compositionAntrag, biopsieSection);
+            };
 
             // Vorbefund (Antrag.biopsie.vorbefund)
             src.operations as operations, operations where "crfid = %caseIndex.toString() + '-VB' + %index.formIndex.toString() and type = 'save'  and data.exists()" then

--- a/CDS Maps/nNGM-CDS-to-FHIR-Master.map
+++ b/CDS Maps/nNGM-CDS-to-FHIR-Master.map
@@ -15,7 +15,7 @@ imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_BasisangabenFHIR"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_Anforderung"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_TNMFHIR"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_ResistenztestungFHIR"
-// imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundFHIR"
+imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundFHIR"
 
 // Befund
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_ImmunhistochemieFHIR"
@@ -40,9 +40,9 @@ group MapCDS(source src: CTS_Transport, target tgt: Bundle)
     src -> tgt.id = uuid();
     src -> tgt.type = 'collection';
 
-    src then MapStammdaten(src, tgt);
+    // src then MapStammdaten(src, tgt);
     src then MapAntrag(src, tgt);
-    src then MapBefund(src, tgt);
+    // src then MapBefund(src, tgt);
     // TODO
     // src then MapTherapies(src, tgt);
     src then MapTNM(src, tgt);
@@ -159,11 +159,11 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
 
         /* ------------------------------ Resources ---------------------------- */
 
-        // Basisangaben (Antrag.basisangaben)
-        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" then
-        {
-            src then TransformBundleBasisangaben(operations, bundleAntrag, compositionAntrag);
-        };
+        // // Basisangaben (Antrag.basisangaben)
+        // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" then
+        // {
+        //     src then TransformBundleBasisangaben(operations, bundleAntrag, compositionAntrag);
+        // };
 
         // Biopsie(n) (Antrag.biopsie) (Create one biopsy section per biopsie)
         src then InitFormIndex(src, index); // the formIndex indicates which biopsie (an thus which biopsieSection) should be created
@@ -178,29 +178,29 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
                                                 formularId.value = evaluate(index, '$this.formIndex.toString()');
 
             /* ------------------------------ Resources ---------------------------- */
-            // Anforderung (Antrag.biopsie.anforderung)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            {
-                src then TransformBundleAnforderung(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            };
-
-            // TNM (Antrag.biopsie.tnm)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            {
-                src then TransformBundleTNM(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            };
-
-            // Resistenztestung (Antrag.biopsie.resistenztestung)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
-            {
-                src then TransformBundleResistenztestung(operations, bundleAntrag, compositionAntrag, biopsieSection);
-            };
-
-            // // Vorbefund (Antrag.biopsie.vorbefund)
-            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-VB' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            // // Anforderung (Antrag.biopsie.anforderung)
+            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
             // {
-            //     src then TransformBundleVorbefundFHIR(operations, bundleAntrag, compositionAntrag, biopsieSection, index);
+            //     src then TransformBundleAnforderung(operations, bundleAntrag, compositionAntrag, biopsieSection);
             // };
+
+            // // TNM (Antrag.biopsie.tnm)
+            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            // {
+            //     src then TransformBundleTNM(operations, bundleAntrag, compositionAntrag, biopsieSection);
+            // };
+
+            // // Resistenztestung (Antrag.biopsie.resistenztestung)
+            // src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            // {
+            //     src then TransformBundleResistenztestung(operations, bundleAntrag, compositionAntrag, biopsieSection);
+            // };
+
+            // Vorbefund (Antrag.biopsie.vorbefund)
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-VB' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            {
+                src then TransformBundleVorbefundFHIR(operations, bundleAntrag, compositionAntrag, biopsieSection, index);
+            };
 
             src then IncrementFormIndex(src, index);
         };

--- a/CDS Maps/nNGM-FHIR-to-CDS-Master.map
+++ b/CDS Maps/nNGM-FHIR-to-CDS-Master.map
@@ -14,7 +14,7 @@ imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_BasisangabenCDS"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_AnforderungCDS"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_TNMCDS"
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_ResistenztestungCDS"
-// imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundCDS"
+imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_VorbefundCDS"
 
 // Befund
 imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_BeurteilungCDS"
@@ -682,6 +682,23 @@ group TransformCheckboxesVorbefund(source src: Bundle, source nestedSection: Bac
             observation where "%observation.code.coding.code = 'KRAS Exon 2'" -> data.values as values, values.value = 'KRAS Exon 2';
             // need to only check for EGFR Exon 19 since 19, 20 and 21 are selected/identified via this one value below
             observation where "%observation.code.coding.code = 'EGFR Exon 19'" -> data.values as values, values.value = 'EGFR Exon 19-21'; 
+        };
+    };
+
+    // LP
+    nestedSection where "code.coding.code = 'vorbefund'" -> operations.data as data then
+    {
+        nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference,
+        src.entry as entry, entry.resource as observation where "resource.id = %reference.split(\'/\').last() and resource is Observation 
+                                                            and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-panel'" then
+        {
+            observation where "%data.where(itemid = 'id_2513').exists().not()" then
+            {
+                observation -> data.blockindex = 2;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid = 'id_2513';
+                observation -> data.values as values, values.value = 'yes';
+            };
         };
     };
 }

--- a/CDS Maps/nNGM-FHIR-to-CDS-Master.map
+++ b/CDS Maps/nNGM-FHIR-to-CDS-Master.map
@@ -138,51 +138,10 @@ group MapAntrag(source src: Bundle, target tgt: CTS_Transport)
                 };
             };
 
-            // TNM (Antrag.biopsie.tnm)
-            biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'tnm'" -> tgt.operations as operations then
-            {
-                let crfidLeft = append(fallNummer, '-TNM');
-
-                nestedSection -> tgt.version = '1.0';
-                nestedSection -> operations.type = 'save';
-                nestedSection -> operations.crfid = append(crfidLeft, formNummer);
-
-                nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
-                {
-                    src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
-                    {
-                        nestedSection then TransformTNMCDS(entry, operations);
-                    };
-                };
-            };
-            
-            // Resistenztestung (Antrag.biopsie.resistenztestung)
-            biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'resistenztestung'" -> tgt.operations as operations then
-            {
-                let crfidLeft = append(fallNummer, '-RT');
-
-                nestedSection -> tgt.version = '1.0';
-                nestedSection -> operations.type = 'save';
-                nestedSection -> operations.crfid = append(crfidLeft, formNummer);
-
-                nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
-                {
-                    src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
-                    {
-                        nestedSection then TransformResistenztestungCDS(entry, operations);
-                    };
-                };
-
-                nestedSection then TransformCheckboxes(src, nestedSection, operations);
-            };
-
-            // // Vorbefund (Antrag.biopsie.vorbefund)
-            // biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'vorbefund'" -> tgt.operations as operations then
+            // // TNM (Antrag.biopsie.tnm)
+            // biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'tnm'" -> tgt.operations as operations then
             // {
-            //     let crfidLeft = append(fallNummer, '-VB');
-            //     let index = create('RepeatIndex'); // repeatindex needed for NGS Lung Panel and Fusion NGS
-            //     src then InitSectionIndex(src, index); // used for NGS Lung Panel
-            //     src then InitCaseIndex(src, index);  // used for Fusion NGS
+            //     let crfidLeft = append(fallNummer, '-TNM');
 
             //     nestedSection -> tgt.version = '1.0';
             //     nestedSection -> operations.type = 'save';
@@ -192,19 +151,60 @@ group MapAntrag(source src: Bundle, target tgt: CTS_Transport)
             //     {
             //         src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
             //         {
-            //             nestedSection then TransformVorbefundCDS(entry, operations, index);
+            //             nestedSection then TransformTNMCDS(entry, operations);
+            //         };
+            //     };
+            // };
+            
+            // // Resistenztestung (Antrag.biopsie.resistenztestung)
+            // biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'resistenztestung'" -> tgt.operations as operations then
+            // {
+            //     let crfidLeft = append(fallNummer, '-RT');
 
-            //             entry where "resource is Observation 
-            //                         and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-panel'" then
-            //                         IncrementSectionIndex(src, index);
-            //             entry where "resource is Observation and resource.code.coding.code = 'Sonstiges'
-            //                         and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
-            //                         IncrementCaseIndex(src, index);
+            //     nestedSection -> tgt.version = '1.0';
+            //     nestedSection -> operations.type = 'save';
+            //     nestedSection -> operations.crfid = append(crfidLeft, formNummer);
+
+            //     nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
+            //     {
+            //         src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
+            //         {
+            //             nestedSection then TransformResistenztestungCDS(entry, operations);
             //         };
             //     };
 
-            //     nestedSection then TransformCheckboxesVorbefund(src, nestedSection, operations);
+            //     nestedSection then TransformCheckboxes(src, nestedSection, operations);
             // };
+
+            // Vorbefund (Antrag.biopsie.vorbefund)
+            biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'vorbefund'" -> tgt.operations as operations then
+            {
+                let crfidLeft = append(fallNummer, '-VB');
+                let index = create('RepeatIndex'); // repeatindex needed for NGS Lung Panel and Fusion NGS
+                src then InitSectionIndex(src, index); // used for NGS Lung Panel
+                src then InitCaseIndex(src, index);  // used for Fusion NGS
+
+                nestedSection -> tgt.version = '1.0';
+                nestedSection -> operations.type = 'save';
+                nestedSection -> operations.crfid = append(crfidLeft, formNummer);
+
+                nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
+                {
+                    src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
+                    {
+                        nestedSection then TransformVorbefundCDS(entry, operations, index);
+
+                        entry where "resource is Observation 
+                                    and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-panel'" then
+                                    IncrementSectionIndex(src, index);
+                        entry where "resource is Observation and resource.code.coding.code = 'Sonstige Fusion NGS'
+                                    and resource.meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Observation/ngs-fusion-expression'" then
+                                    IncrementCaseIndex(src, index);
+                    };
+                };
+
+                nestedSection then TransformCheckboxesVorbefund(src, nestedSection, operations);
+            };
         };
     };
 }

--- a/CDS Maps/nNGM-FHIR-to-CDS-Master.map
+++ b/CDS Maps/nNGM-FHIR-to-CDS-Master.map
@@ -138,43 +138,43 @@ group MapAntrag(source src: Bundle, target tgt: CTS_Transport)
                 };
             };
 
-            // // TNM (Antrag.biopsie.tnm)
-            // biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'tnm'" -> tgt.operations as operations then
-            // {
-            //     let crfidLeft = append(fallNummer, '-TNM');
+            // TNM (Antrag.biopsie.tnm)
+            biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'tnm'" -> tgt.operations as operations then
+            {
+                let crfidLeft = append(fallNummer, '-TNM');
 
-            //     nestedSection -> tgt.version = '1.0';
-            //     nestedSection -> operations.type = 'save';
-            //     nestedSection -> operations.crfid = append(crfidLeft, formNummer);
+                nestedSection -> tgt.version = '1.0';
+                nestedSection -> operations.type = 'save';
+                nestedSection -> operations.crfid = append(crfidLeft, formNummer);
 
-            //     nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
-            //     {
-            //         src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
-            //         {
-            //             nestedSection then TransformTNMCDS(entry, operations);
-            //         };
-            //     };
-            // };
+                nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
+                {
+                    src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
+                    {
+                        nestedSection then TransformTNMCDS(entry, operations);
+                    };
+                };
+            };
             
-            // // Resistenztestung (Antrag.biopsie.resistenztestung)
-            // biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'resistenztestung'" -> tgt.operations as operations then
-            // {
-            //     let crfidLeft = append(fallNummer, '-RT');
+            // Resistenztestung (Antrag.biopsie.resistenztestung)
+            biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'resistenztestung'" -> tgt.operations as operations then
+            {
+                let crfidLeft = append(fallNummer, '-RT');
 
-            //     nestedSection -> tgt.version = '1.0';
-            //     nestedSection -> operations.type = 'save';
-            //     nestedSection -> operations.crfid = append(crfidLeft, formNummer);
+                nestedSection -> tgt.version = '1.0';
+                nestedSection -> operations.type = 'save';
+                nestedSection -> operations.crfid = append(crfidLeft, formNummer);
 
-            //     nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
-            //     {
-            //         src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
-            //         {
-            //             nestedSection then TransformResistenztestungCDS(entry, operations);
-            //         };
-            //     };
+                nestedSection.entry as nestedSectionEntry, nestedSectionEntry.reference as reference then
+                {
+                    src.entry as entry, entry where "resource.id = %reference.split(\'/\').last()" then
+                    {
+                        nestedSection then TransformResistenztestungCDS(entry, operations);
+                    };
+                };
 
-            //     nestedSection then TransformCheckboxes(src, nestedSection, operations);
-            // };
+                nestedSection then TransformCheckboxes(src, nestedSection, operations);
+            };
 
             // Vorbefund (Antrag.biopsie.vorbefund)
             biopsieSection.section as nestedSection, nestedSection where "code.coding.code = 'vorbefund'" -> tgt.operations as operations then


### PR DESCRIPTION
### Fix Vorbefund map (normal and reverse)

In this branch I fixed the Vorbefund map (CDS-to-FHIR) and the reverse Vorbefund map(FHIR-to-CDS) and applied the profile changes.


**Changes**
- add Specimen reference to Vorbefund Observations (CDS-to-FHIR)
- fix the Histologie Observation url to use the correct canonical url (with lower case "nngm")
- refactor the FHIR-to-CDS map to be structured more granular into separate groups
- fix a few typos in other maps


**TODO**

- CDS-to-FHIR: The NGS Panel Device has no uuid (like "uuid_device") in the CDS-Export and currently uses a workaround by creating a new uuid, see Redmine Ticket 10380