### PR TITLE
Feature/add copositions only if needed

### DIFF
--- a/CDS Maps/nNGM-CDS-to-FHIR-Master.map
+++ b/CDS Maps/nNGM-CDS-to-FHIR-Master.map
@@ -51,7 +51,7 @@ group MapCDS(source src: CTS_Transport, target tgt: Bundle)
 /* ------------------------------ Stammdaten ---------------------------- */
 group MapStammdaten(source src: CTS_Transport, target tgt: Bundle)
 {
-    src.operations as operations, operations where "crfid = 'SD' and type = 'save'" ->
+    src.operations as operations, operations where "crfid = 'SD' and type = 'save' and data.exists()" ->
         tgt.entry as entry,
         entry.resource = create('Bundle') as bundleStammdaten,
         bundleStammdaten.entry as entryStammdaten,
@@ -107,7 +107,7 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
 
     src.operations as operations,
         // Execute as many times as there are Basisangaben
-        operations where "crfid = %index.caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" ->
+        operations where "crfid = %index.caseIndex.toString() + '-BA' and type = 'save' and data.exists()" ->
         // Add a transaction bundle to the collection bundle
         tgt.entry as entry,
         entry.resource = create('Bundle') as bundleAntrag,
@@ -160,7 +160,7 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
         /* ------------------------------ Resources ---------------------------- */
 
         // Basisangaben (Antrag.basisangaben)
-        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" then
+        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BA' and type = 'save' and data.exists()" then
         {
             src then TransformBundleBasisangaben(operations, bundleAntrag, compositionAntrag);
         };
@@ -179,25 +179,25 @@ group MapAntrag(source src: CTS_Transport, target tgt: Bundle)
 
             /* ------------------------------ Resources ---------------------------- */
             // Anforderung (Antrag.biopsie.anforderung)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-AF' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleAnforderung(operations, bundleAntrag, compositionAntrag, biopsieSection);
             };
 
             // TNM (Antrag.biopsie.tnm)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-TNM' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleTNM(operations, bundleAntrag, compositionAntrag, biopsieSection);
             };
 
             // Resistenztestung (Antrag.biopsie.resistenztestung)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-RT' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleResistenztestung(operations, bundleAntrag, compositionAntrag, biopsieSection);
             };
 
             // Vorbefund (Antrag.biopsie.vorbefund)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-VB' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-VB' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleVorbefundFHIR(operations, bundleAntrag, compositionAntrag, biopsieSection, index);
             };
@@ -221,7 +221,7 @@ group MapBefund(source src: CTS_Transport, target tgt: Bundle)
 
     src.operations as operations,
     // Execute as many times as there are Basisangaben
-    operations where "crfid = %index.caseIndex.toString() + '-BA' and type = 'save'  and data.exists()" ->
+    operations where "crfid = %index.caseIndex.toString() + '-BA' and type = 'save' and data.exists()" ->
     // Add a transaction bundle to the collection bundle
     tgt.entry as entry,
     entry.resource = create('Bundle') as bundleBefund,
@@ -298,37 +298,37 @@ group MapBefund(source src: CTS_Transport, target tgt: Bundle)
             };
 
             // Molekularpathologie (Befund.diagnostik.molekularpathologie)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-MP' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-MP' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleMolekularpathologie(operations, bundleBefund, compositionBefund, diagnosticSection);
             };
 
             // NGS Lung Panel (Befund.diagnostik.ngs-lung-panel)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-LP' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-LP' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleNGSLungPanel(operations, bundleBefund, compositionBefund, diagnosticSection, index);
             };
 
             // Fusion NGS (Befund.diagnostik.ngs-fusion-expression)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-FS' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-FS' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleFusionNGS(operations, bundleBefund, compositionBefund, diagnosticSection, index);
             };
 
             // Fast Track (Befund.diagnostik.fast-track)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-FT' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-FT' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleFastTrack(operations, bundleBefund, compositionBefund, diagnosticSection);
             };
 
             // Sonstige Untersuchungen (Befund.diagnostik.sonstige-untersuchungen)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-SU' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-SU' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleSonstigeUntersuchungen(operations, bundleBefund, compositionBefund, diagnosticSection, index);
             };
             
             // Liquid Biopsy (Befund.diagnostik.liquid-biopsy)
-            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-LB' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = %caseIndex.toString() + '-LB' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleLiquidBiopsy(operations, bundleBefund, compositionBefund, diagnosticSection, index);
             };
@@ -347,7 +347,7 @@ group MapBefund(source src: CTS_Transport, target tgt: Bundle)
         };
 
         // Beurteilung (Befund.beurteilung)
-        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BU' and type = 'save'  and data.exists()" then
+        src.operations as operations, operations where "crfid = %caseIndex.toString() + '-BU' and type = 'save' and data.exists()" then
         {
             src then TransformBundleBeurteilung(operations, bundleBefund, compositionBefund, index);
         };
@@ -420,7 +420,7 @@ group MapTherapies(source src: CTS_Transport, target tgt: Bundle)
 
             // Operation
             src then InitFormIndex(src, index);
-            src.operations as operations, operations where "crfid = 'OP' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = 'OP' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 // src then TransformBundleOperationTherapie(operations, bundleTherapie, compositionTherapie, sectionTherapie);
                 src then IncrementFormIndex(src, index);
@@ -428,7 +428,7 @@ group MapTherapies(source src: CTS_Transport, target tgt: Bundle)
 
             // SystemischeTherapie
             src then InitFormIndex(src, index);
-            src.operations as operations, operations where "crfid = 'SY' + %index.formIndex.toString() and type = 'save'  and data.exists()" then
+            src.operations as operations, operations where "crfid = 'SY' + %index.formIndex.toString() and type = 'save' and data.exists()" then
             {
                 src then TransformBundleSystemischeTherapie(operations, bundleTherapie, compositionTherapie, sectionTherapie);
                 src then IncrementFormIndex(src, index);
@@ -445,7 +445,7 @@ group MapTNM(source src: CTS_Transport, target tgt: Bundle)
     src then InitMaxIndexTNM(src, index); // Reset maxIndex
 
     /* ------------------------------ TNM ---------------------------- */
-    src ->
+    src where "$this.operations.where(crfid.contains('TNM') and crfid.contains('-').not() and type = 'save' and data.exists()).exists()" ->
     // Add a transaction bundle to the collection bundle
     tgt.entry as entry,
     entry.resource = create('Bundle') as bundleTNM,
@@ -464,6 +464,7 @@ group MapTNM(source src: CTS_Transport, target tgt: Bundle)
         /* ------------------------------ Composition ---------------------------- */
 
         // Meta
+        src -> compositionTNM.title = 'TNM Pseudonymisiert';
         src -> compositionTNM.id = uuid();
         src -> compositionTNM.meta as meta collate, meta.profile = 'http://uk-koeln.de/fhir/StructureDefinition/Composition/nNGM/TNM-pseudonymisiert';
         src -> entryTNM.request as request, request.method = 'PUT', request.url = evaluate(compositionTNM, '\'Composition/\' + $this.id');
@@ -473,9 +474,6 @@ group MapTNM(source src: CTS_Transport, target tgt: Bundle)
 
         // Category idat or psn depends on which type of patient/consent is in the bundle
         src -> compositionTNM.category = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/composition-category', 'psn');
-
-        // Title
-        src -> compositionTNM.title = 'TNM Pseudonymisiert';
 
         // Status
         src -> compositionTNM.status = cast('final', 'FHIR.code');
@@ -497,7 +495,7 @@ group MapTNM(source src: CTS_Transport, target tgt: Bundle)
         src.operations as operations, operations where "%index.formIndex <= %maxIndex" -> compositionTNM.section as compositionSection then
         {
             src.operations as operations,
-                    operations where "crfid = 'TNM' + %index.formIndex.toString() and type = 'save'" -> 
+                    operations where "crfid = 'TNM' + %index.formIndex.toString() and type = 'save' and data.exists()" -> 
                     compositionTNM.section = create('BackboneElement') as section,
                     section.title = 'TNM',
                     section.code = cc('http://uk-koeln.de/fhir/CodeSystem/nngm/sections', 'tnm') then
@@ -562,7 +560,7 @@ group InitMaxIndexAntrag(source src: CTS_Transport, target index: RepeatIndex)
     src -> index.maxIndex = 1;
 
     // Anforderung
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-AF') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-AF') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-AF\') + \'-AF\'.length()).toInteger() > %index.maxIndex"
@@ -570,7 +568,7 @@ group InitMaxIndexAntrag(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // TNM
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-TNM') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-TNM') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-TNM\') + \'-TNM\'.length()).toInteger() > %index.maxIndex"
@@ -578,7 +576,7 @@ group InitMaxIndexAntrag(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Resistenztestung
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-RT') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-RT') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-RT\') + \'-RT\'.length()).toInteger() > %index.maxIndex"
@@ -586,7 +584,7 @@ group InitMaxIndexAntrag(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Vorbefund
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-VB') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-VB') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-VB\') + \'-VB\'.length()).toInteger() > %index.maxIndex"
@@ -603,7 +601,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     src -> index.maxIndex = 1;
 
     // Histologie
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-HL') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-HL') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-HL\') + \'-HL\'.length()).toInteger() > %index.maxIndex"
@@ -611,7 +609,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Immunhistochemie
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-IHC') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-IHC') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-IHC\') + \'-IHC\'.length()).toInteger() > %index.maxIndex"
@@ -619,7 +617,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // NGS Lung Panel
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-LP') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-LP') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-LP\') + \'-LP\'.length()).toInteger() > %index.maxIndex"
@@ -627,7 +625,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Molekularpathologie
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-MP') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-MP') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-MP\') + \'-MP\'.length()).toInteger() > %index.maxIndex"
@@ -635,7 +633,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Fusion NGS
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-FS') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-FS') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-FS\') + \'-FS\'.length()).toInteger() > %index.maxIndex"
@@ -643,7 +641,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Fast Track
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-FT') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-FT') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-FT\') + \'-FT\'.length()).toInteger() > %index.maxIndex"
@@ -651,7 +649,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Sonstige Untersuchungen
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-SU') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-SU') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-SU\') + \'-SU\'.length()).toInteger() > %index.maxIndex"
@@ -659,7 +657,7 @@ group InitMaxIndexBefund(source src: CTS_Transport, target index: RepeatIndex)
     };
 
     // Liquid Biopsy
-    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-LB') and type = 'save'  and data.exists()" then
+    src.operations as operations, operations where "crfid.contains(%caseIndex.toString() + '-LB') and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'-LB\') + \'-LB\'.length()).toInteger() > %index.maxIndex"
@@ -673,7 +671,7 @@ group InitMaxIndexTNM(source src: CTS_Transport, target index: RepeatIndex)
     src -> index.maxIndex = 1;
 
     // TNM
-    src.operations as operations, operations where "crfid.contains('TNM') and crfid.contains('-').not() and type = 'save'" then
+    src.operations as operations, operations where "crfid.contains('TNM') and crfid.contains('-').not() and type = 'save' and data.exists()" then
     {
         // isolate formIndex from crfid, if this formIndex is bigger than maxIndex: assign it to maxIndex
         operations where "crfid.substring($this.crfid.indexOf(\'TNM\') + \'TNM\'.length()).toInteger() > %index.maxIndex"

--- a/CDS Maps/nNGM-CDS-to-FHIR-Master.map
+++ b/CDS Maps/nNGM-CDS-to-FHIR-Master.map
@@ -367,7 +367,8 @@ group MapTherapies(source src: CTS_Transport, target tgt: Bundle)
 
     /* ------------------------------ Therapien ---------------------------- */
     src then InitCaseIndex(src, index); // Reset index
-    src ->
+    // Execute once if there are any Therapie forms
+    src where "$this.operations.where(crfid.contains('-').not() and (crfid.contains('OP') or crfid.contains('SY') or crfid.contains('ST') or crfid.contains('SO')) and type = 'save' and data.exists()).exists()" ->
     // Add a transaction bundle to the collection bundle
     tgt.entry as entry,
     entry.resource = create('Bundle') as bundleTherapie,
@@ -447,6 +448,7 @@ group MapTNM(source src: CTS_Transport, target tgt: Bundle)
     src then InitMaxIndexTNM(src, index); // Reset maxIndex
 
     /* ------------------------------ TNM ---------------------------- */
+    // Execute once if there are any TNM forms
     src where "$this.operations.where(crfid.contains('TNM') and crfid.contains('-').not() and type = 'save' and data.exists()).exists()" ->
     // Add a transaction bundle to the collection bundle
     tgt.entry as entry,

--- a/CDS Maps/nNGM-CDS-to-FHIR-Master.map
+++ b/CDS Maps/nNGM-CDS-to-FHIR-Master.map
@@ -219,9 +219,11 @@ group MapBefund(source src: CTS_Transport, target tgt: Bundle)
     src then InitCaseIndex(src, index); // Reset caseIndex
     src then InitMaxIndexBefund(src, index); // Reset maxIndex
 
-    src.operations as operations,
-    // Execute as many times as there are Basisangaben
-    operations where "crfid = %index.caseIndex.toString() + '-BA' and type = 'save' and data.exists()" ->
+    src.operations as operations, 
+    // Execute as many times as there are any Befund forms for each caseIndex
+    operations where "$this.where(crfid.contains(%index.caseIndex.toString() + '-') 
+                    and (crfid.contains('-IHC') or crfid.contains('-HL') or crfid.contains('-MP') or crfid.contains('-LP') or crfid.contains('-FS') or crfid.contains('-FT') or crfid.contains('-SU') or crfid.contains('-LB') or crfid.contains('-BU'))
+                    and type = 'save' and data.exists())" ->
     // Add a transaction bundle to the collection bundle
     tgt.entry as entry,
     entry.resource = create('Bundle') as bundleBefund,


### PR DESCRIPTION
### Add Compositions only if needed

In this branch I added checks to the mapping groups in the Master.map to ensure that Compositions are only created, if corresponding data exists in the CDS_Transport. So now (despite the meta information) empty Composition is created. Those checks are working as follows:

Stammdaten: 1 Composition per Stammdaten
Antrag: 1 Composition per Basisangaben (according to caseIndex)
Befund: 1 Composition per caseIndex with at least 1 Befund Form
Therapies: 1 Composition if there is at least 1 Therapie Form
TNM: 1 Composition if there is at least 1 TNM Form


**Changes**
- add checks to Therapie and TNM
- change check for Befund to make it independent of Antrag's Basisangaben
- add missing checks for data.exists() and remove double blank spaces


**Remarks**
- Therapie mapping group wasn't finished at the time of posing this PR, so it's probably best to first deal with PR. However, I already tested my approach without transforming the Therapies itself and the Therapie-Composition was created (or not created) as expected.