### PR TITLE
Feature/adjust resistenztestung (task #10688)

### DIFF
--- a/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
+++ b/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
@@ -226,25 +226,25 @@ group TransformObservationEGFRResistenztestung(source operations: BackboneElemen
         // 1. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1441'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
         };
     
         // 2. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1442'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
         };
     
         // 3. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1443'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
         };
     
         // 4. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1444'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
         };
 
         // Mutations
@@ -312,25 +312,25 @@ group TransformObservationALKResistenztestung(source operations: BackboneElement
         // 1. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1447'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
         };
     
         // 2. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1448'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
         };
     
         // 3. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1449'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
         };
     
         // 4. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1450'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
         };
     };
 }
@@ -379,25 +379,25 @@ group TransformObservationROS1Resistenztestung(source operations: BackboneElemen
         // 1. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1453'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 1;
         };
     
         // 2. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1454'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 2;
         };
     
         // 3. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1455'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 3;
         };
     
         // 4. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1456'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueCodeableConcept as vcc, vcc.text = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), ttherapie.valueString = value therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
         };
     };
 }

--- a/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
+++ b/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
@@ -397,7 +397,7 @@ group TransformObservationROS1Resistenztestung(source operations: BackboneElemen
         // 4. Therapie
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1456'" then
         {
-             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), ttherapie.valueString = value therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
+             values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
         };
     };
 }

--- a/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
+++ b/ClinicalDocumentationSystem/IndividualMaps/CDS-to-FHIR/nNGM-CDS-to-FHIR-Resistenztestung.map
@@ -247,7 +247,7 @@ group TransformObservationEGFRResistenztestung(source operations: BackboneElemen
              values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), therapie.valueString = value, therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
         };
 
-        // Mutations
+        // EGFR-Mutations
         // Exon
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1436'" then
         {
@@ -398,32 +398,6 @@ group TransformObservationROS1Resistenztestung(source operations: BackboneElemen
         data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1456'" then
         {
              values.value as value -> tgt.component = create('BackboneElement') as therapie, therapie.code = cc('http://ncit.nci.nih.gov', 'C62721'), ttherapie.valueString = value therapie.extension as componentOrder, componentOrder.url = 'http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order', componentOrder.value = 4;
-        };
-    };
-}
-
-/* ------------------------------ Add mutations to observation ---------------------------- */
-// The mutations are the same for each observation so we can separate them into groups and then simply call them for each observation
-group TransformMutationsResistenztestung(source operations: BackboneElement, target tgt: Observation)
-{
-    operations.data as data then
-    {
-        // Exon
-        data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1436'" then
-        {
-             values.value as value -> tgt.component = create('BackboneElement') as exon, exon.valueString = value, exon.code = cc('http://ncit.nci.nih.gov', 'C13231');
-        };
-    
-        // HGVS c
-        data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1437'" then
-        {
-             values.value as value -> tgt.component = create('BackboneElement') as hgvsc, hgvsc.valueString = value, hgvsc.code = cc('http://loinc.org', '48004-6');
-        };
-
-        // HGVS p
-        data.values as values where "blockindex = 1 and groupindex = 0 and itemid = 'id_1438'" then
-        {
-             values.value as value -> tgt.component = create('BackboneElement') as hgvsp, hgvsp.valueString = value, hgvsp.code = cc('http://loinc.org', '48005-3');
         };
     };
 }

--- a/ClinicalDocumentationSystem/IndividualMaps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Resistenztestung.map
+++ b/ClinicalDocumentationSystem/IndividualMaps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Resistenztestung.map
@@ -73,9 +73,6 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
         // Observation.effectiveDateTime -> 1, 0, 2502
         observation then TransformEffectiveDateTimeObservation(observation, tgt);
 
-        // Mutations
-        observation then TransformMutationsCDSResistenztestung(observation, tgt);
-
         // Therapien
         observation.component as components, components where "$this.code.coding.code = 'C62721'" then
         {
@@ -115,6 +112,43 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component.valueString as valueString -> data.values as values, values.value = valueString;
             };
         };
+
+        // EGFR-Mutations 
+        // Observation.component.exon -> 1, 0, 1436
+        observation.component as component, component where "$this.code.coding.code = 'C13231'" then
+        {
+            component -> tgt.data as data then
+            {   
+                observation -> data.blockindex = 1;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid = 'id_1436';
+                component.valueString as valuestring -> data.values as values, values.value = valuestring;
+            };
+        };
+
+        // Observation.component.hgvsc -> 1, 0, 1437
+        observation.component as component, component where "$this.code.coding.code = '48004-6'" then
+        {
+            component -> tgt.data as data then
+            {   
+                observation -> data.blockindex = 1;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid = 'id_1437';
+                component.valueString as valuestring -> data.values as values, values.value = valuestring;
+            };
+        };
+
+        // Observation.component.hgvsp -> 1, 0, 1438
+        observation.component as component, component where "$this.code.coding.code = '48005-3'" then        
+        {
+            component -> tgt.data as data then
+            {   
+                observation -> data.blockindex = 1;
+                observation -> data.groupindex = 0;
+                observation -> data.itemid = 'id_1438';
+                component.valueString as valuestring -> data.values as values, values.value = valuestring;
+            };
+        };
     };
 
     /* ------------------------------ Observation ALK ---------------------------- */
@@ -122,9 +156,6 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
     {
         // Observation.effectiveDateTime -> 1, 0, 2502
         observation then TransformEffectiveDateTimeObservation(observation, tgt);
-        
-        // Mutations
-        observation then TransformMutationsCDSResistenztestung(observation, tgt);
 
         // Observation.Fusionpartner -> 1, 0, 2504
         observation.component as components, components as component where "$this.code.coding.code = 'C28510'" -> tgt.data as data then
@@ -181,9 +212,6 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
     {
         // Observation.effectiveDateTime -> 1, 0, 2502
         observation then TransformEffectiveDateTimeObservation(observation, tgt);
-
-        // Mutations
-        observation then TransformMutationsCDSResistenztestung(observation, tgt);
 
         // Observation.Fusionpartner -> 1, 0, 2506
         observation.component as components, components as component where "$this.code.coding.code = 'C28510'" -> tgt.data as data then
@@ -246,58 +274,6 @@ group TransformEffectiveDateTimeObservation(source observation: Observation, tar
             effectiveDateTime -> data.groupindex = 0;
             effectiveDateTime -> data.itemid = 'id_2502';
             effectiveDateTime -> data.values as values, values.value = effectiveDateTime;
-        };
-    };
-}
-
-group TransformMutationsCDSResistenztestung(source observation: Observation, target tgt: BackboneElement)
-{
-    observation then
-    {
-        // Mutations 
-        // Observation.component.exon -> 1, 0, 1436
-        observation.component as components where "%tgt.data.where(itemid = 'id_1436').exists().not()" then 
-        {
-            components as component where "$this.code.coding.code = 'C13231'" then
-            {
-                component -> tgt.data as data then
-                {   
-                    observation -> data.blockindex = 1;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid = 'id_1436';
-                    component.valueString as valuestring -> data.values as values, values.value = valuestring;
-                };
-            };
-        };
-
-        // Observation.component.hgvsc -> 1, 0, 1437
-        observation.component as components where "%tgt.data.where(itemid = 'id_1437').exists().not()" then 
-        {
-            components as component where "$this.code.coding.code = '48004-6'" then 
-            {
-                component -> tgt.data as data then
-                {   
-                    observation -> data.blockindex = 1;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid = 'id_1437';
-                    component.valueString as valuestring -> data.values as values, values.value = valuestring;
-                };
-            };
-        };
-
-        // Observation.component.hgvsp -> 1, 0, 1438
-        observation.component as components where "%tgt.data.where(itemid = 'id_1438').exists().not()" then 
-        {
-            components as component where "$this.code.coding.code = '48005-3'" then 
-            {
-                component -> tgt.data as data then
-                {   
-                    observation -> data.blockindex = 1;
-                    observation -> data.groupindex = 0;
-                    observation -> data.itemid = 'id_1438';
-                    component.valueString as valuestring -> data.values as values, values.value = valuestring;
-                };
-            };
         };
     };
 }

--- a/ClinicalDocumentationSystem/IndividualMaps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Resistenztestung.map
+++ b/ClinicalDocumentationSystem/IndividualMaps/FHIR-to-CDS/nNGM-FHIR-to-CDS-Resistenztestung.map
@@ -85,7 +85,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1441';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 2. Therapie
@@ -94,7 +94,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1442';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 3. Therapie
@@ -103,7 +103,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1443';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 4. Therapie
@@ -112,7 +112,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1444';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
         };
     };
@@ -144,7 +144,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1447';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
             
             // 2. Therapie
@@ -153,7 +153,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1448';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 3. Therapie
@@ -162,7 +162,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1449';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 4. Therapie
@@ -171,7 +171,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1450';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
         };
     };
@@ -203,7 +203,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1453';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 2. Therapie
@@ -212,7 +212,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1454';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 3. Therapie
@@ -221,7 +221,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1455';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
 
             // 4. Therapie
@@ -230,7 +230,7 @@ group TransformResistenztestungCDS(source entry: BackboneElement, target tgt: Ba
                 component -> data.blockindex = 1;
                 component -> data.groupindex = 0;
                 component -> data.itemid = 'id_1456';
-                component.valueCodeableConcept as valueCodeableConcept, valueCodeableConcept.text as text -> data.values as values, values.value = text;
+                component.valueString as valueString -> data.values as values, values.value = valueString;
             };
         };
     };


### PR DESCRIPTION
This branch fixes the tkiTherapie component to use valueString instead of valueCodeableConcept so that we don't have to map strings to valueCodeableConcept.text. Changes are applied to both directions FHIR-to-CDS and CDS-to-FHIR.

Please note: The Mutations (Exon, HGVSc and HGVSp) are called "EGFR-Mutations" in the CDS and thus are only needed for the EGFR-Observation. I therefore removed the not longer needed mapping groups.

Changes were tested with Conversion and Transformation with 2 - Antrag Pseudonymisiert - Example.json and 1. Patient-CDS-Export.json