### PR TITLE
Remove sourcesystem

### DIFF
--- a/ClinicalDocumentationSystem/nNGM-FHIR-to-CDS-Master.map
+++ b/ClinicalDocumentationSystem/nNGM-FHIR-to-CDS-Master.map
@@ -37,14 +37,11 @@ imports "http://uk-koeln.de/fhir/StructureMap/nNGM_Mapping_SystemischeTherapieCT
 
 group MapCDS(source src: Bundle, target tgt: CTS_Transport)
 {
-    src -> tgt.sourcesystem = 'https:\/\/nngm-qat.staging.healex.systems\/';
-
     src then MapStammdaten(src, tgt);
     src then MapAntrag(src, tgt);
     src then MapBefund(src, tgt);
     src then MapTNM(src, tgt);
     src then MapTherapie(src, tgt);
-    
 }
 
 group MapStammdaten(source src: Bundle, target tgt: CTS_Transport)


### PR DESCRIPTION
This removes the hardcoded sourcesystem as it is a potential security threat to the testing infrastructure. 